### PR TITLE
Modify lexer to treat leading whitespace like other indent-based languages

### DIFF
--- a/lib/lexer.js
+++ b/lib/lexer.js
@@ -65,9 +65,10 @@ var unit = new RegExp('^(-)?(\\d+\\.\\d+|\\d+|\\.\\d+)(' + units + ')? *');
 
 var Lexer = module.exports = function Lexer(str, options) {
   options = options || {};
-  this.str = str.replace(/\r\n?/g, '\n').replace(/\t/g, '  ');
+  this.str = str.replace(/\r\n?/g, '\n');
   this.stash = [];
-  this.prevIndents = 0;
+  this.indentStack = [];
+  this._indentRE = null;
   this.lineno = 0;
 };
 
@@ -200,9 +201,12 @@ Lexer.prototype = {
 
   get eos() {
     if (this.str.length) return;
-    return --this.prevIndents < 0
-      ? new Token('eos')
-      : new Token('outdent');
+    if (this.indentStack.length === 0) {
+      return new Token('eos');
+    } else {
+      this.indentStack.shift();
+      return new Token('outdent');
+    }
   },
 
   /**
@@ -506,44 +510,48 @@ Lexer.prototype = {
    */
 
   get newline() {
-    var captures;
-    if (captures = /^\n( *)/.exec(this.str)) {
+    var captures, testRE;
+    if (this._indentRE){
+        captures = this._indentRE.exec(this.str);
+    } else {
+      testRE = /^\n([\t]*) */;
+      captures = testRE.exec(this.str);
+      if (captures && !captures[1].length) {
+        testRE = /^\n( *)/;
+        captures = testRE.exec(this.str);
+      }
+      if(captures && captures[1].length) {
+        this._indentRE = testRE;
+      }
+    }
+    if (captures) {
       var tok
-        , spaces = captures[1].length
-        , indents = spaces / 2;
+        , indents = captures[1].length;
 
       this.skip(captures);
+      if (this.str[0] === ' ' || this.str[0] === '\t') {
+        throw new Error('Invalid indentation, you can use tabs or spaces to indent but not both');
+      }
 
       // Reset state
       this.isVariable = false;
-      
+
       // Blank line
       if ('\n' == this.str[0]) {
         ++this.lineno;
         return this.advance;
       }
 
-      // To few spaces
-      if (0 != spaces % 2) {
-        var str = 1 == spaces ? 'space' : 'spaces'
-          , spaces = numberString[spaces] || spaces;
-        throw new Error('Invalid indentation, got ' + spaces + ' ' + str + ' and expected multiple of two');
-      // To many spaces
-      } else if (indents > this.prevIndents + 1) {
-        var str = 1 == spaces ? 'space' : 'spaces'
-          , expected = 2 * (this.prevIndents * 2) || 2
-          , expected = numberString[expected] || expected
-          , spaces = numberString[spaces] || spaces;
-        throw new Error('Invalid indentation, got ' + spaces + ' ' + str + ' and expected ' + expected);
       // Outdent
-      } else if (indents < this.prevIndents) {
-        var n = this.prevIndents - indents;
-        while (--n) this.stash.push(new Token('outdent'));
-        this.prevIndents = indents;
-        tok = new Token('outdent');
+      if (this.indentStack.length && indents < this.indentStack[0]) {
+        while (this.indentStack.length && this.indentStack[0] > indents) {
+          this.stash.push(new Token('outdent'));
+          this.indentStack.shift();
+        }
+        tok = this.stash.pop();
       // Indent
-      } else if (indents != this.prevIndents) {
-        this.prevIndents = indents;
+      } else if (indents && indents != this.indentStack[0]) {
+        this.indentStack.unshift(indents);
         tok = new Token('indent');
       // Newline
       } else {

--- a/test/cases/css.whitespace.css
+++ b/test/cases/css.whitespace.css
@@ -3,6 +3,17 @@ body {
 }
 body {
   padding: 5px;
+}
+body {
+  padding: 5px;
+  margin: 0;
+}
+body {
+  padding: 5px;
+  margin: 0;
+}
+body {
+  padding: 5px;
   margin: 0;
 }
 body {

--- a/test/cases/css.whitespace.styl
+++ b/test/cases/css.whitespace.styl
@@ -3,7 +3,19 @@ body
   padding 5px
 
 body
+ padding 5px
+
+body
   padding: 5px;  margin: 0;
+
+body
+    padding: 5px;
+    margin: 0;
+
+body {
+     padding: 5px;
+  margin: 0;
+}
 
 body {
   padding: 5px;  margin: 0;


### PR DESCRIPTION
This patch allows an arbitrary amount of spaces to be used to indent. The constraints should match up to Python 3 and Coffeescript in that you can use tabs or spaces but not both. Spaces trailing tabs are fine (used for alignment) and do not contribute to the indent level.
