### PR TITLE
fixed: Bug where having different src and dest would cause incorrect path generation

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -12,6 +12,7 @@ var stylus = require('./stylus')
   , fs = require('fs')
   , url = require('url')
   , basename = require('path').basename
+  , dirname = require('path').dirname
   , join = require('path').join
   , ENOENT;
 
@@ -112,8 +113,10 @@ module.exports = function(options){
     if ('GET' != req.method && 'HEAD' != req.method) return next();
     var path = url.parse(req.url).pathname;
     if (/\.css$/.test(path)) {
-      var cssPath = join(dest, path)
-        , stylusPath = join(src, path.replace('.css', '.styl'));
+      var common = commonality( dest, path )
+        , adjustPath = common ? path.replace(common, '') : path
+        , cssPath = join(dest, adjustPath)
+        , stylusPath = join(src, adjustPath.replace('.css', '.styl'));
 
       if (debug) {
         log('source', stylusPath);
@@ -220,6 +223,38 @@ function checkImports(path, fn) {
       }
     });
   });
+}
+
+/**
+ * Find the commonality between a base dir and a request path.
+ *
+ * @param {String} base Base path
+ * @param {String} path Request path
+ * @param {String} separator Dir separator (default "/")
+ * @api private
+ */
+
+function commonality ( a, b, sep ) {
+  sep = sep || '/';
+
+  // Normalisation
+  b = dirname( b );
+  if ( a[ a.length - 1 ] == sep )
+    a = a.slice( 0, -1 );
+  if ( b[0] == sep )
+    b = b.slice( 1 );
+
+  var b_split = b.split( sep )
+    , len = b_split.length
+    , i
+    , m
+    , match;
+
+  for ( i = 0; i < len; i++ ) {
+    m = new RegExp( b_split.slice( 0, i + 1 ).join( sep ) + '$' ).exec( a );
+    if ( m )
+      return m[0];
+  }
 }
 
 /**


### PR DESCRIPTION
Currently if one sets `src` and `dest` to different directories, incorrect final stylus and css locations are generated. For example, let's assume the following locations are used:

```
{ src: '/Project/stylesheets', dest: '/Project/public/stylesheets/generated' }
```

And the request path is `/stylesheets/generated/main.css`. Then the following final stylus and css locations are generated:

```
source == '/Projects/stylesheets/stylesheets/generated/main.styl'
dest == '/Projects/public/stylesheets/generated/stylesheets/generated/style.css'
```

These paths are obviously incorrect. I've fixed Stylus so that the paths are generated as follows:

```
source == '/Projects/stylesheets/main.styl'
dest == '/Projects/public/stylesheets/generated/style.css'
```
