### PR TITLE
Pink color is back

### DIFF
--- a/lib/nodes/hsla.js
+++ b/lib/nodes/hsla.js
@@ -214,7 +214,8 @@ HSLA.prototype.adjustHue = function(deg){
  */
 
 function clampDegrees(n) {
-  return Math.abs(n % 360);
+  n = n % 360;
+  return n >= 0 ? n : 360 + n;
 }
 
 /**


### PR DESCRIPTION
Hi TJ
Here's a fix for hsla color manipulation. The problem was that lighten(pink) was returning yellow !

Before :

> hsla(#FF0)
> => hsla(60,100,50,1)
> hsla(#F0F)
> => hsla(**60**,100,50,1)

Now :

> hsla(#FF0)
> => hsla(60,100,50,1)
> hsla(#F0F)
> => hsla(**300**,100,50,1)
