### PR TITLE
Sublime Text compatibiity for syntax highlighting

### DIFF
--- a/editors/Stylus.tmbundle/Syntaxes/Stylus.tmLanguage
+++ b/editors/Stylus.tmbundle/Syntaxes/Stylus.tmLanguage
@@ -13,7 +13,7 @@
 	<array>
 		<dict>
 			<key>match</key>
-			<string>^ *(&amp;|)</string>
+			<string>^ *(\&|)</string>
 			<key>name</key>
 			<string>variable.language.stylus</string>
 		</dict>


### PR DESCRIPTION
`&amp;` made it freak out, but it's comfortable with `\&`
