### PR TITLE
Specify Stylus specific comments preferences

### DIFF
--- a/editors/Stylus.tmbundle/Preferences/Comments.tmPreferences
+++ b/editors/Stylus.tmbundle/Preferences/Comments.tmPreferences
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>name</key>
+	<string>Comments</string>
+	<key>scope</key>
+	<string>source.stylus</string>
+	<key>settings</key>
+	<dict>
+		<key>shellVariables</key>
+		<array>
+			<dict>
+				<key>name</key>
+				<string>TM_COMMENT_START</string>
+				<key>value</key>
+				<string>// </string>
+			</dict>
+			<dict>
+				<key>name</key>
+				<string>TM_COMMENT_START_2</string>
+				<key>value</key>
+				<string>/*</string>
+			</dict>
+			<dict>
+				<key>name</key>
+				<string>TM_COMMENT_END_2</string>
+				<key>value</key>
+				<string>*/</string>
+			</dict>
+		</array>
+	</dict>
+	<key>uuid</key>
+	<string>7EC85265-178C-4ECC-AAE2-4EEF4AFF8872</string>
+</dict>
+</plist>


### PR DESCRIPTION
This patch overrides the defaults from the **TextMate** _Source_ bundle. Using the _Comment Line_ (⌘/) and _Insert Block Comment_ (⌥⌘/) commands now properly applies the correct kind of markers for commenting out selections. Usually this helps me avoid indentation errors.

Nice work on **stylus** :)

Cheers,
Daniel

_P.S. This was inspired by the_ JavaScript _bundle’s preferences. (See what I did there, TJ? I didn’t even mention CoffeeScript) ;)_

/cc @aseemk
