### PR TITLE
Implement ‘Compile and Display CSS’ command.

### DIFF
--- a/editors/Stylus.tmbundle/Commands/Compile and Display CSS.tmCommand
+++ b/editors/Stylus.tmbundle/Commands/Compile and Display CSS.tmCommand
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>beforeRunningCommand</key>
+	<string>nop</string>
+	<key>command</key>
+	<string>#!/bin/bash
+
+function highlight {
+  test `which pygmentize`
+  if [[ $? -eq 0 ]]; then
+    pygmentize -Onoclasses,nobackground=True -l css -f html
+  else
+    pre
+  fi
+}
+
+${TM_STYLUS:=stylus} | highlight</string>
+	<key>input</key>
+	<string>selection</string>
+	<key>keyEquivalent</key>
+	<string>@b</string>
+	<key>name</key>
+	<string>Compile and Display CSS</string>
+	<key>output</key>
+	<string>showAsHTML</string>
+	<key>scope</key>
+	<string>source.stylus</string>
+	<key>uuid</key>
+	<string>DD8F8C2B-2B83-4734-82EE-8508EE344638</string>
+</dict>
+</plist>


### PR DESCRIPTION
Title says it all. Press **⌘B** in a _Stylus_ document or selection and watch the magic. Best used with [pygments](http://pygments.org/) (`pip install pygments`) installed.
#### TODO
- Strip indentation
- Don’t use `pygmentize` on errors

Cheers,
Daniel

_P.S. Sorry, TJ, I have to admit, this was inspired by [CoffeeScript’s TextMate bundle](https://github.com/jashkenas/coffee-script-tmbundle/blob/master/Commands/Compile%20and%20Display%20JS.tmCommand) ;)_

/cc @aseemk
