### PR TITLE
Fixed caching behavior for recompilation of files with changed imports.

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -137,10 +137,11 @@ module.exports = function(options){
           if (err) return error(err);
           var style = options.compile(str, stylusPath);
           var paths = style.options._imports = [];
+          delete imports[stylusPath];
           style.render(function(err, css){
             if (err) return next(err);
             if (debug) log('render', stylusPath);
-            imports[stylusPath] = imports[stylusPath] || paths;
+            imports[stylusPath] = paths;
             fs.writeFile(cssPath, css, 'utf8', function(err){
               next(err);
             });
@@ -172,8 +173,12 @@ module.exports = function(options){
             // Already compiled, check imports
             } else {
               checkImports(stylusPath, function(changed){
-                if (debug && changed) log('modified import', changed);
-                changed ? compile() : next();
+                if (debug && changed.length > 0) {
+                  changed.forEach(function(changedPath) {
+                    log('modified import', changedPath);
+                  });
+                }
+                changed.length > 0 ? compile() : next();
               });
             }
           }
@@ -199,25 +204,15 @@ function checkImports(path, fn) {
   if (!nodes.length) return fn();
 
   var pending = nodes.length
-    , changed = false;
+    , changed = [];
 
   nodes.forEach(function(import){
     fs.stat(import.path, function(err, stat){
-      // error
-      if (err) {
-        --pending || fn(changed);
-      // compare mtimes
-      } else if (import.mtime) {
-        if (!changed) changed = stat.mtime > import.mtime
-          ? import.path
-          : false;
-        import.mtime = stat.mtime;
-        --pending || fn(changed);
-      // first hit, ignore
-      } else {
-        import.mtime = stat.mtime;
-        --pending || fn(changed);
+      // error or newer mtime
+      if (err || !import.mtime || stat.mtime > import.mtime) {
+        changed.push(import.path);
       }
+      --pending || fn(changed);
     });
   });
 }

--- a/lib/visitor/evaluator.js
+++ b/lib/visitor/evaluator.js
@@ -580,6 +580,11 @@ Evaluator.prototype.visitImport = function(import){
     throw err;
   }
 
+  // Store the modified time
+  fs.stat(found, function(err, stat){
+    if (!err) import.mtime = stat.mtime;
+  });
+
   // Evaluate imported "root"
   block.parent = root;
   block.scope = false;


### PR DESCRIPTION
@stevekrenzel noticed a bug regarding watching for changed imports.

When some file A.styl imports some other file B.styl, the `imports` array tracks it. When you change A.styl to also import C.styl, then A.styl gets recompiled, but the `imports` array wasn't getting overridden with the new list of imports `['B.styl', 'C.styl']`. As a result, changes to C.styl were not causing recompilation.
