### PR TITLE
Rename variables named "import"

### DIFF
--- a/bin/stylus
+++ b/bin/stylus
@@ -484,9 +484,9 @@ function watch(file, fn) {
  */
 
 function watchImports(file, imports) {
-  imports.forEach(function(import){
-    if (!import.path) return;
-    watch(import.path, function(){
+  imports.forEach(function(importObj){
+    if (!importObj.path) return;
+    watch(importObj.path, function(){
       compileFile(file);
     });
   });

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -206,11 +206,11 @@ function checkImports(path, fn) {
   var pending = nodes.length
     , changed = [];
 
-  nodes.forEach(function(import){
-    fs.stat(import.path, function(err, stat){
+  nodes.forEach(function(importObj){
+    fs.stat(importObj.path, function(err, stat){
       // error or newer mtime
-      if (err || !import.mtime || stat.mtime > import.mtime) {
-        changed.push(import.path);
+      if (err || !importObj.mtime || stat.mtime > importObj.mtime) {
+        changed.push(importObj.path);
       }
       --pending || fn(changed);
     });

--- a/lib/visitor/compiler.js
+++ b/lib/visitor/compiler.js
@@ -344,8 +344,8 @@ Compiler.prototype.visitCall = function(call){
  * Visit Import.
  */
 
-Compiler.prototype.visitImport = function(import){
-  return '@import ' + this.visit(import.path) + ';';
+Compiler.prototype.visitImport = function(importObj){
+  return '@import ' + this.visit(importObj.path) + ';';
 };
 
 /**

--- a/lib/visitor/evaluator.js
+++ b/lib/visitor/evaluator.js
@@ -536,18 +536,18 @@ Evaluator.prototype.visitIf = function(node){
  * Visit Import.
  */
 
-Evaluator.prototype.visitImport = function(import){
+Evaluator.prototype.visitImport = function(importObj){
   var found
     , root = this.root
     , Parser = require('../parser')
-    , path = this.visit(import.path).first;
+    , path = this.visit(importObj.path).first;
 
   // Enusre string
   if (!path.string) throw new Error('@import string expected');
   var name = path = path.string;
 
   // Literal
-  if (/\.css$/.test(path)) return import;
+  if (/\.css$/.test(path)) return importObj;
   path += '.styl';
 
   // Lookup
@@ -555,10 +555,10 @@ Evaluator.prototype.visitImport = function(import){
   found = found || utils.lookup(name + '/index.styl', this.paths, this.filename);
 
   // Expose imports
-  import.path = found;
-  import.dirname = dirname(found);
-  this.paths.push(import.dirname);
-  if (this.options._imports) this.options._imports.push(import);
+  importObj.path = found;
+  importObj.dirname = dirname(found);
+  this.paths.push(importObj.dirname);
+  if (this.options._imports) this.options._imports.push(importObj);
 
   // Throw if import failed
   if (!found) throw new Error('failed to locate @import file ' + path);
@@ -583,7 +583,7 @@ Evaluator.prototype.visitImport = function(import){
   // Store the modified time
   fs.stat(found, function(err, stat){
     if (err) return;
-    import.mtime = stat.mtime;
+    importObj.mtime = stat.mtime;
   });
 
   // Evaluate imported "root"


### PR DESCRIPTION
Alpha-renaming variables named "import" to "importObj".  "import" is a reserved word.  Fixes #303

All tests pass on my installation of node 0.5.1.
