### PR TITLE
Rename all variables called "import" as it is a keyword

### DIFF
--- a/bin/stylus
+++ b/bin/stylus
@@ -484,9 +484,9 @@ function watch(file, fn) {
  */
 
 function watchImports(file, imports) {
-  imports.forEach(function(import){
-    if (!import.path) return;
-    watch(import.path, function(){
+  imports.forEach(function(watchImport){
+    if (!watchImport.path) return;
+    watch(watchImport.path, function(){
       compileFile(file);
     });
   });

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -206,11 +206,11 @@ function checkImports(path, fn) {
   var pending = nodes.length
     , changed = [];
 
-  nodes.forEach(function(import){
-    fs.stat(import.path, function(err, stat){
+  nodes.forEach(function(import_){
+    fs.stat(import_.path, function(err, stat){
       // error or newer mtime
-      if (err || !import.mtime || stat.mtime > import.mtime) {
-        changed.push(import.path);
+      if (err || !import_.mtime || stat.mtime > import_.mtime) {
+        changed.push(import_.path);
       }
       --pending || fn(changed);
     });

--- a/lib/visitor/compiler.js
+++ b/lib/visitor/compiler.js
@@ -344,8 +344,8 @@ Compiler.prototype.visitCall = function(call){
  * Visit Import.
  */
 
-Compiler.prototype.visitImport = function(import){
-  return '@import ' + this.visit(import.path) + ';';
+Compiler.prototype.visitImport = function(import_){
+  return '@import ' + this.visit(import_.path) + ';';
 };
 
 /**

--- a/lib/visitor/evaluator.js
+++ b/lib/visitor/evaluator.js
@@ -536,18 +536,18 @@ Evaluator.prototype.visitIf = function(node){
  * Visit Import.
  */
 
-Evaluator.prototype.visitImport = function(import){
+Evaluator.prototype.visitImport = function(import_){
   var found
     , root = this.root
     , Parser = require('../parser')
-    , path = this.visit(import.path).first;
+    , path = this.visit(import_.path).first;
 
   // Enusre string
   if (!path.string) throw new Error('@import string expected');
   var name = path = path.string;
 
   // Literal
-  if (/\.css$/.test(path)) return import;
+  if (/\.css$/.test(path)) return import_;
   path += '.styl';
 
   // Lookup
@@ -555,10 +555,10 @@ Evaluator.prototype.visitImport = function(import){
   found = found || utils.lookup(name + '/index.styl', this.paths, this.filename);
 
   // Expose imports
-  import.path = found;
-  import.dirname = dirname(found);
-  this.paths.push(import.dirname);
-  if (this.options._imports) this.options._imports.push(import);
+  import_.path = found;
+  import_.dirname = dirname(found);
+  this.paths.push(import_.dirname);
+  if (this.options._imports) this.options._imports.push(import_);
 
   // Throw if import failed
   if (!found) throw new Error('failed to locate @import file ' + path);
@@ -583,7 +583,7 @@ Evaluator.prototype.visitImport = function(import){
   // Store the modified time
   fs.stat(found, function(err, stat){
     if (err) return;
-    import.mtime = stat.mtime;
+    import_.mtime = stat.mtime;
   });
 
   // Evaluate imported "root"


### PR DESCRIPTION
When I start bin/stylus from the GIT directory, I get errors that import is a keyword and cannot be used as variable name.

Weirdly enough, it works when I just installed stylus with npm. Any ideas?

In case we should rename all import variables, here is the patch.
