### PR TITLE
Don't prepend the working directory for the --use option of the CLI tool

### DIFF
--- a/bin/stylus
+++ b/bin/stylus
@@ -497,9 +497,7 @@ function watchImports(file, imports) {
  */
 
 function usePlugins(style) {
-  var cwd = process.cwd();
   plugins.forEach(function(path){
-    path = join(cwd, path);
     fn = require(path);
     if ('function' != typeof fn) {
       throw new Error('plugin ' + path + ' does not export a function');


### PR DESCRIPTION
This makes the behavior consistent with the --out and --watch properties where it is possible to use full paths.
