### PR TITLE
fixed: Output from --help in stylus executable cut-off half way through

### DIFF
--- a/bin/stylus
+++ b/bin/stylus
@@ -134,7 +134,7 @@ while (args.length) {
   switch (arg) {
     case '-h':
     case '--help':
-      console.log(usage);
+      console.error(usage);
       process.exit(1);
     case '-d':
     case '--compare':


### PR DESCRIPTION
Output from stylus executable was cut off half way through due to the process exiting prematurely (see end of description). I imagine this is possibly not reproducible at different computers as execution speed might matter.

One solution were to let the process exit naturally instead of forcing `process.exit(1)`, however it seems that changing `console.log` to `console.error` changes the behavior from non-blocking to blocking. Given that the process exits with error code, this is perhaps an appropriate change (and fixes the problem).

Current broken behavior:

```
jakub$ stylus --help

  Usage: stylus [options] [command] [< in [> out]]
                [file|dir ...]

  Commands:

    help [<type>:]<prop> Opens help info at MDC for <prop> in
                         your default browser. Optionally
                         searches other resources of <type>:
                         safari opera w3c ms caniuse quirksmode

  Options:

    -i, --interactive       Start interactive REPL
    -u, --use <path>        Utilize the stylus plugin at <path>
    -U, --inline            Utilize image inlining via data uri support
    -w, --watch             Watch file(s) for changes and re-compile
    -o, --out <dir>         Output to <dir> when passing files
    -C, --css <src> [dest]  Convert css input to stylus
    -I, --include <path>    Add <path> to lookup paths
    -c, --compress          Compress css output
    -d, --compare           Display input along with output
    -f, --firebug           Emits debug infos in the generated css that
                            can be ujakub-air:apiary jakub$
```
