### PR TITLE
Fix Issue 422 - rgb percentage values do not work correctly

### DIFF
--- a/lib/functions/index.js
+++ b/lib/functions/index.js
@@ -271,10 +271,13 @@ exports.rgba = function rgba(red, green, blue, alpha){
       utils.assertType(green, 'unit', 'green');
       utils.assertType(blue, 'unit', 'blue');
       utils.assertType(alpha, 'unit', 'alpha');
+      var r = '%' == red.type ? Math.round(red.val * 2.55) : red.val;
+      var g = '%' == green.type ? Math.round(green.val * 2.55) : green.val;
+      var b = '%' == blue.type ? Math.round(blue.val * 2.55) : blue.val;
       return new nodes.RGBA(
-          red.val
-        , green.val
-        , blue.val
+          r
+        , g
+        , b
         , alpha.val);
   }
 };

--- a/test/cases/literal.color.css
+++ b/test/cases/literal.color.css
@@ -3,4 +3,6 @@ body {
   color: rgba(255,204,0,0.40);
   color: #fc0;
   color: rgba(255,204,0,0.40);
+  color: #fff;
+  color: rgba(255,255,255,0.50);
 }

--- a/test/cases/literal.color.styl
+++ b/test/cases/literal.color.styl
@@ -3,3 +3,5 @@ body
   color: #fc06
   color: #ffcc00
   color: #ffcc0066
+  color: rgb(100%,255,100%)
+  color: rgba(100%,255,100%,0.5)


### PR DESCRIPTION
Played with http://learnboost.github.com/stylus/try and found an rgb() issue in a couple minutes. I then spent the next hour and a half fixing it! Very cool project.

I tried to mimic your style but everyone's different so you might want to make an adjustment. I haven't read the complete specs/docs yet so I'm not sure how compatible this is with operations on color values but I don't expect any issues.
