### PR TITLE
Export Compiler for plugin use

### DIFF
--- a/lib/stylus.js
+++ b/lib/stylus.js
@@ -57,6 +57,7 @@ exports.middleware = require('./middleware');
 exports.Visitor = require('./visitor');
 exports.Parser = require('./parser');
 exports.Evaluator = require('./visitor/evaluator');
+exports.Compiler = require('./visitor/compiler');
 
 /**
  * Convert the given `css` to `stylus` source.


### PR DESCRIPTION
Exporting the Compiler object. Allows for plugins to evaluate AST in the same ALA the url builtin arguments.
