### PR TITLE
New CIELAB node

### DIFF
--- a/lib/nodes/cielab.js
+++ b/lib/nodes/cielab.js
@@ -174,19 +174,18 @@ CIELAB.prototype.lab_adjust = function(L,a,b,alpha){
  * @api public
  */
 
-CIELAB.prototype.monochrome = function(n, hue) {
+CIELAB.prototype.monochrome = function(n, lightness, mode) {
   var hlc = cielab_to_hlc(this);
 
+  // Default darken
+  mode = (mode == 'lighten') ? 1 : -1;
+
   var mono = [this];
-  var h;
   for (var c=1; n>c; c++) {
-    h = hlc[0] + c * hue;
-    h = (h >= 360) ? h-360 : h;
-    h = (h < 0) ? h+360 : h;
 
     mono.push(hlc_to_cielab(
-        h
-      , hlc[1]
+        hlc[0]
+      , hlc[1] + c * lightness * mode
       , hlc[2]
       , hlc[3]
     ));


### PR DESCRIPTION
I have written a new node for the CIE-L_a_b\* color space. It has also support for CIE-L*CH. In addition you can provide RAL Design(TM) colors directly via their color card number (CIE-HCL schema).

 I have tried to integrate it with stylus, but failed so far. Unfortunately I have no time at the moment to make further work. If someone would be kind enough to do the rest. It would be great.

The functions are not well tested, but I have verified the important Lab to RGB function, the L*CH to Lab and the RAL Design to Lab. 

The node contains functions to manipulate the color via Hue, Lightness, Chroma, a, b and of course the alpha channel. In addition I have written functions for creating multiple CIELAB nodes as a monochrome, gradient or the colors complement strips. All of the tree do return an array with CIELAB color nodes. I don't now if this goes into the stylus concept. 

The functions in detail:
-   CIELAB.prototype.lab_adjust = function(L,a,b,alpha) : Can be used to implement the add or sub function or general manipulation of the Lab node.
-   CIELAB.prototype.hlc_adjust = function(H,L,C,alpha) : Can be used to implement the add or sub function or general manipulation of the Lab node via an HLC syntax.
-   CIELAB.prototype.monochrome = function(n, lightness, mode) : Creates an array of n CIELAB nodes with lightness as delta between colors. Mode can be 'darken' or 'lighten'. Defaults to darken.
-   CIELAB.prototype.complement = function(n) : Creates an array of n CIELAB nodes with equal hue distance. With this function it is very easy to create perfectly distributed complement colors, because CIE-L_a_b\* reflects the sensitivity of the human eye. The values are calculated via CIE-L*CH values.
-   CIELAB.prototype.gradient = function(n, cielab, mode) : Creates an array of n CIELAB nodes with gradient from given color to 'cielab'. In the mode you can select, if you want to use the bigger angle. The value is calculated via CIE-L*CH and the hue is a range from 0 to 360 degree. Because it is a circle, it is possible to get a gradient with the shorter angle between the points or the longer. The default uses the shorter one.
-   CIELAB.prototype.toString : Returns #nnnnnn, #nnn, or rgba(n,n,n,n) RGBA string. Because it makes no sense in the current state of CSS, to give back CIELAB values :) Because HSL and RGB are color profile dependent, I have decided to stick with RGB values. The irony is, that Safari, Chrome respecting the color profile in pictures, but it is not possible to submit color profiles for the color values in CSS :) I hope, one day L*CH values in CSS will be possible.
-   exports.CIEHLC = function(H,L,C,alpha) : Creates a CIELAB node via the RAL Design, CIE-HLC values.
-   exports.CIELCH = function(L,C,H,alpha) : Creates a CIELAB node via the CIE-L*CH values.
-   exports.fromRGBA = function(rgba) : Creates a CIELAB node from an RGBA node.

The rest are private helper functions. All calculations are base on a 2 degree observer (CIE 1931) and the default sRGB D65 illuminant.
