### PR TITLE
Added LESS-inspired 'spin' method.

### DIFF
--- a/lib/functions/index.styl
+++ b/lib/functions/index.styl
@@ -104,6 +104,16 @@ darken(color, amount)
 lighten(color, amount)
   adjust(color, 'lightness', amount)
 
+// spin hue by a given amount (taken from LESS)
+spin(color, amount)
+  h = hue(color)
+  s = saturation(color)
+  l = lightness(color)
+  a = alpha(color)
+  hue = (h + amount) % 360
+  h = hue < 0 ? 360 + hue : hue
+  return hsla(h,s,l,a)
+
 // return the last value in the given expr
 
 last(expr)


### PR DESCRIPTION
LESS has a _spin_ method for modifying the hue of a color by a specified amount.  In many cases of porting LESS to stylus I've needed this method and may find it useful for others to have it as well.

If not in core, should this be added to something like nib?
