### PR TITLE
Correct path resolving in stylus binary

### DIFF
--- a/bin/stylus
+++ b/bin/stylus
@@ -608,7 +608,7 @@ function usePlugins(style) {
   plugins.forEach(function(plugin){
     var path = plugin.path;
     var options = plugin.options;
-    fn = require(resolve(path));
+    fn = require(/^\.+\//.test(path) ? resolve(path) : path);
     if ('function' != typeof fn) {
       throw new Error('plugin ' + path + ' does not export a function');
     }


### PR DESCRIPTION
- `./relative/paths` resolve relative to cwd.
- `/absolute/paths` resolve as is.
- `library` resolve as `require(library)`.
