### PR TITLE
Added DocPad to the support listing as it supports Stylus out of the box

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -110,6 +110,10 @@ form input {
    - [Connect](/LearnBoost/stylus/blob/master/docs/middleware.md)
    - [Ruby On Rails](https://github.com/lucasmazza/stylus_rails)
 
+### CMS Support
+
+   - [DocPad](https://github.com/balupton/docpad)
+
 ### Screencasts
 
   - [Stylus Intro](http://screenr.com/bNY)


### PR DESCRIPTION
Sent a pull request for this as a lot of DocPad users are finding DocPad to be a fantastic way to get started with Stylus and use it in their own projects :-)
