### PR TITLE
More textmate bundle improvements

### DIFF
--- a/editors/Stylus.tmbundle/Syntaxes/Stylus.tmLanguage
+++ b/editors/Stylus.tmbundle/Syntaxes/Stylus.tmLanguage
@@ -113,7 +113,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>((?:!|~|\+|-|(?:\*)?\*|\/|%|(?:\.)\.\.|&lt;|&gt;|in|(?:=|:|\?|\+|-|\*|\/|%|&lt;|&gt;)?=|!=|)|(?:is(?:nt)?|not)\b)</string>
+			<string>((?:!|~|\+|-|(?:\*)?\*|\/|%|(?:\.)\.\.|&lt;|&gt;|(?:=|:|\?|\+|-|\*|\/|%|&lt;|&gt;)?=|!=)|(?:in|is(?:nt)?|not)\b)</string>
 			<key>name</key>
 			<string>keyword.operator.stylus</string>
 		</dict>


### PR DESCRIPTION
Extends #494.
- Added highlighting of CSS color aliases (black / white / red etc.)
- Added highlighting of font families (serif, sans serif, helvetica etc.)
- Added highlighting of HTML tags (html, body, h1 etc.)
- Added highlighting of stylus operators (=, is, isn't, +, \* etc.)
- Fixed invalid coloring of values (e.g. in "0.2" only "0" was colored)

![](http://f.cl.ly/items/2g451h0B1g0w3g352j2f/Screen%20Shot%202011-12-29%20at%2011.52.17%20PM.png)
![](http://f.cl.ly/items/2e2O3Y0B0M2g1C3e3k1M/Screen%20Shot%202011-12-30%20at%2012.34.43%20AM.png)
