### PR TITLE
Changed fs.watchFile to new fs.watch

### DIFF
--- a/bin/stylus
+++ b/bin/stylus
@@ -579,7 +579,7 @@ function watch(file, fn) {
   fs.stat(file, function(err, stat){
     console.log('  \033[90mwatching\033[0m %s', file);
     mtime = stat.mtime.getTime();
-    watcher = fs.watch(file, { interval: 50 }, watchCallback);
+    watcher = fs.watch(file, watchCallback);
   });
 }
 


### PR DESCRIPTION
Since fs.watchFile API no longer functions in these latest versions of Node.js I updated it to the new fs.watch to make it work on node 0.6.6 on Windows.

I understand more changes are needed to make this work in all versions supported but this made the --watch option work on Windows.
