### PR TITLE
Gave the stylus middleware a name.

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -107,7 +107,7 @@ module.exports = function(options){
   };
 
   // Middleware
-  return function(req, res, next){
+  return function stylus(req, res, next){
     if ('GET' != req.method && 'HEAD' != req.method) return next();
     var path = url.parse(req.url).pathname;
     if (/\.css$/.test(path)) {


### PR DESCRIPTION
Again all the other connect middlewares are named functions.

My personal use-case is unit testing. I can identify that a particular middleware fn in the stack is stylus by using `middleware.name === 'stylus'`
