### PR TITLE
Fixed missing 'new' operator.

### DIFF
--- a/lib/nodes/boolean.js
+++ b/lib/nodes/boolean.js
@@ -75,7 +75,7 @@ Boolean.prototype.__defineGetter__('isFalse', function(){
  */
 
 Boolean.prototype.negate = function(){
-  return Boolean(!this.val);
+  return new Boolean(!this.val);
 };
 
 /**


### PR DESCRIPTION
This causes "global leak: lineno" in tests.
