### PR TITLE
Textmate bundle cleanup/addition

### DIFF
--- a/editors/Stylus.tmbundle/Syntaxes/Stylus.tmLanguage
+++ b/editors/Stylus.tmbundle/Syntaxes/Stylus.tmLanguage
@@ -67,7 +67,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>(:)\b(active|hover|link|visited|focus|lang|first-child|last-child|only-child|nth-child|first-of-type|last-of-type|nth-of-type|nth-last-of-type|only-of-type|empty|target|enabled|disabled|checked|root|not)\b</string>
+			<string>(:)\b(active|hover|focus|target|link|any-link|local-link|visited|scope|current|past|future|dir|lang|enabled|disabled|checked|indeterminate|default|valid|invalid|in-range|out-of-range|required|optional|read-only|read-write|root|first-child|last-child|only-child|nth-child|nth-last-child|first-of-type|last-of-type|nth-of-type|nth-last-of-type|only-of-type|nth-match|nth-last-match|empty|not|column|nth-column|nth-last-column)\b</string>
 			<key>name</key>
 			<string>entity.other.attribute-name.pseudo-class.stylus</string>
 		</dict>


### PR DESCRIPTION
Also: have you considered moving this bundle into its own repo? so that it can be easily cloned and used as a working copy in whichever editor we're using.

or is there a good way to do this despite it being nested in the stylus repo?
