### PR TITLE
Fixed broken comment highlighting

### DIFF
--- a/editors/Stylus.tmbundle/Syntaxes/Stylus.tmLanguage
+++ b/editors/Stylus.tmbundle/Syntaxes/Stylus.tmLanguage
@@ -12,6 +12,34 @@
 	<key>patterns</key>
 	<array>
 		<dict>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.comment.stylus</string>
+				</dict>
+			</dict>
+			<key>match</key>
+			<string>(?:^[ \t]+)?(\/\/).*$\n?</string>
+			<key>name</key>
+			<string>comment.line.stylus</string>
+		</dict>
+		<dict>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>entity.name.function.stylus</string>
+				</dict>
+			</dict>
+			<key>match</key>
+			<string>([-a-zA-Z_][-\w]*)?(\()</string>
+			<key>name</key>
+			<string>meta.function.stylus</string>
+		</dict>
+		<dict>
 			<key>match</key>
 			<string>^ *(&amp;|)</string>
 			<key>name</key>
@@ -111,9 +139,10 @@
 			<key>name</key>
 			<string>keyword.control.stylus</string>
 		</dict>
+
 		<dict>
 			<key>match</key>
-			<string>((?:!|~|\+|-|(?:\*)?\*|\/|%|(?:\.)\.\.|&lt;|&gt;|(?:=|:|\?|\+|-|\*|\/|%|&lt;|&gt;)?=|!=)|(?:in|is(?:nt)?|not)\b)</string>
+			<string>((?:!|~|\+|-|(?:\*)?\*|\/|%|(?:\.)\.\.|&lt;|&gt;|(?:=|:|\?|\+|-|\*|\/|%|&lt;|&gt;)?=|!=)|\b(?:in|is(?:nt)?|not)\b)</string>
 			<key>name</key>
 			<string>keyword.operator.stylus</string>
 		</dict>
@@ -149,34 +178,7 @@
 			<key>name</key>
 			<string>comment.block.js</string>
 		</dict>
-		<dict>
-			<key>captures</key>
-			<dict>
-				<key>1</key>
-				<dict>
-					<key>name</key>
-					<string>punctuation.definition.comment.stylus</string>
-				</dict>
-			</dict>
-			<key>match</key>
-			<string>(?:^[ \t]+)?(\/\/).*$\n?</string>
-			<key>name</key>
-			<string>comment.line.stylus</string>
-		</dict>
-		<dict>
-			<key>captures</key>
-			<dict>
-				<key>1</key>
-				<dict>
-					<key>name</key>
-					<string>entity.name.function.stylus</string>
-				</dict>
-			</dict>
-			<key>match</key>
-			<string>([-a-zA-Z_][-\w]*)?(\()</string>
-			<key>name</key>
-			<string>meta.function.stylus</string>
-		</dict>
+		
     <dict>
       <key>comment</key>
       <string>http://www.w3.org/TR/CSS21/syndata.html#value-def-color</string>


### PR DESCRIPTION
Comments weren't being properly highlighted because the operator highlighting successfully matches `//`, `/*`and `*/`.

There's probably a regex fix that would solve this, but I just moved the comment pattern definitions above everything else for now, as they should be matched first anyways.

Also added an extra whitespace so that `argin arguments` doesn't match but `arg in arguments` does

cc @paulmillr 
