### PR TITLE
moved block comments to top of syntax, next to single-liners

### DIFF
--- a/editors/Stylus.tmbundle/Syntaxes/Stylus.tmLanguage
+++ b/editors/Stylus.tmbundle/Syntaxes/Stylus.tmLanguage
@@ -25,6 +25,22 @@
 			<key>name</key>
 			<string>comment.line.stylus</string>
 		</dict>
+        <dict>
+            <key>begin</key>
+            <string>/\*</string>
+            <key>captures</key>
+            <dict>
+                <key>0</key>
+                <dict>
+                    <key>name</key>
+                    <string>punctuation.definition.comment.js</string>
+                </dict>
+            </dict>
+            <key>end</key>
+            <string>\*/</string>
+            <key>name</key>
+            <string>comment.block.js</string>
+        </dict>
 		<dict>
 			<key>captures</key>
 			<dict>
@@ -162,23 +178,8 @@
 			<key>name</key>
 			<string>string.quoted.single.stylus</string>
 		</dict>
-		<dict>
-			<key>begin</key>
-			<string>/\*</string>
-			<key>captures</key>
-			<dict>
-				<key>0</key>
-				<dict>
-					<key>name</key>
-					<string>punctuation.definition.comment.js</string>
-				</dict>
-			</dict>
-			<key>end</key>
-			<string>\*/</string>
-			<key>name</key>
-			<string>comment.block.js</string>
-		</dict>
-		
+
+
     <dict>
       <key>comment</key>
       <string>http://www.w3.org/TR/CSS21/syndata.html#value-def-color</string>


### PR DESCRIPTION
they weren't getting matched first and the match for
operators was, so block comments didnt get the quiet
formatting you'd expect

looks like i forgot to move block comments when i moved single-line comments before. didn't notice cuz i don't use block ones too often
