### PR TITLE
Implemented the built-in invert as per #558

### DIFF
--- a/docs/bifs.md
+++ b/docs/bifs.md
@@ -336,6 +336,13 @@ Saturate the given `color` by `amount`.
     saturate(#c33, 40%)
     // => #f00
 
+### invert(color)
+
+Inverts the color. The red, green, and blue values are inverted, while the opacity is left alone.
+
+    invert(#d62828)
+    // => #29d7d7
+
 ### unquote(str | ident)
 
   Unquote the given `str` and returned as a `Literal` node.

--- a/lib/functions/index.styl
+++ b/lib/functions/index.styl
@@ -123,6 +123,14 @@ fade-in(color, amount)
 spin(color, amount)
   color + unit(amount, deg)
 
+// invert colors, leave alpha intact
+
+invert(color)
+  r = 255 - red(color)
+  g = 255 - green(color)
+  b = 255 - blue(color)
+  rgba(r,g,b,alpha(color))
+
 // return the last value in the given expr
 
 last(expr)

--- a/test/cases/bifs.invert.css
+++ b/test/cases/bifs.invert.css
@@ -1,0 +1,7 @@
+body {
+  foo: #000;
+  foo: #fff;
+  foo: #29d7d7;
+  foo: cyan;
+  foo: yellow;
+}

--- a/test/cases/bifs.invert.styl
+++ b/test/cases/bifs.invert.styl
@@ -1,0 +1,6 @@
+body
+  foo: invert(#fff)
+  foo: invert(#000)
+  foo: invert(#d62828)
+  foo: invert(red)
+  foo: invert(blue)


### PR DESCRIPTION
Inverts the color. The red, green, and blue values are inverted, while the opacity is left alone.

Reference: [SASS documentation](http://sass-lang.com/docs/yardoc/Sass/Script/Functions.html#invert-instance_method)
