### PR TITLE
Implemented the built-in mix method as per #549

### DIFF
--- a/lib/functions/index.styl
+++ b/lib/functions/index.styl
@@ -123,6 +123,39 @@ fade-in(color, amount)
 spin(color, amount)
   color + unit(amount, deg)
 
+// mix two colors by a given amount
+
+mix(color1, color2, weight=50%)
+
+  require-color(color1)
+  require-color(color2)
+
+  if weight in 0..100
+    weight = unit(weight, '')
+  else
+    error("Weight must be between 0% and 100%")
+
+  p = (weight/100)
+  w = p*2 - 1
+
+  a = alpha(color1) - alpha(color2)
+
+  w1 = (((w * a == -1) ? w : (w + a)/(1 + w*a)) + 1)/2
+  w2 = 1 - w1
+
+  channels = (red(color1) red(color2)) (green(color1) green(color2)) (blue(color1) blue(color2))
+
+  rgb = ()
+
+  for pair in channels
+    push(rgb, floor(pair[0]*w1 + pair[1]*w2))
+
+  a1 = alpha(color1)*p
+  a2 = alpha(color1)*(1-p)
+  alpha = a1 + a2
+
+  rgba(rgb[0], rgb[1], rgb[2], alpha)
+
 // invert colors, leave alpha intact
 
 invert(color)

--- a/test/cases/bifs.mix.css
+++ b/test/cases/bifs.mix.css
@@ -1,0 +1,5 @@
+body {
+  foo: #7f007f;
+  foo: #3f00bf;
+  foo: rgba(63,0,191,0.75);
+}

--- a/test/cases/bifs.mix.styl
+++ b/test/cases/bifs.mix.styl
@@ -1,0 +1,4 @@
+body
+  foo mix(#f00, #00f)
+  foo mix(#f00, #00f, 25%)
+  foo mix(rgba(255, 0, 0, 0.5), #00f)


### PR DESCRIPTION
This is the implementation found in Sass. It’s copied from Ruby code so it probably could use a little refactoring... It takes account of the opacity correctly.
