### PR TITLE
Fix testing in windoze

### DIFF
--- a/test/run.js
+++ b/test/run.js
@@ -56,6 +56,7 @@ function test(test, fn) {
       if (err) throw err;
       fs.readFile(csspath, 'utf8', function(err, expected){
         if (err) throw err;
+        expected = expected.replace(/\r/g, '');
         if (actual.trim() == expected.trim()) {
           fn();
         } else {


### PR DESCRIPTION
Stylus doesn't expect the `\r\n` that windows text files use (at least in my git).
