### PR TITLE
Improve p() function to accept variable number of args just like console.log; Closes #298.

### DIFF
--- a/lib/functions/index.styl
+++ b/lib/functions/index.styl
@@ -196,3 +196,13 @@ join(delim, vals...)
   vals = vals[0] if length(vals) == 1
   for val, i in vals
     buf += i ? delim + val : val
+
+
+
+add-property-function = add-property
+add-property(name,expr)
+  if mixin
+    {name} expr
+  else
+    add-property-function(name,expr)
+    

--- a/test/cases/bifs.add-property.css
+++ b/test/cases/bifs.add-property.css
@@ -13,6 +13,7 @@ body {
 body {
   foo: -moz-linear-gradient(#eee, #999);
   foo: -webkit-gradient(linear, 0% 0%, 0% 100%, from(#eee), to(#999));
+  color: #000;
 }
 body {
   foo: -webkit-something(15px);

--- a/test/cases/bifs.add-property.styl
+++ b/test/cases/bifs.add-property.styl
@@ -32,6 +32,8 @@ mixin()
 
 body
   mixin()
+  prop = color
+  add-property(prop,#0)
 
 // multiple calls
 


### PR DESCRIPTION
Before:

```
p(moo,meow,woof)

inspect: moo
```

After:

```
p(moo,meow,woof)

inspect: moo
inspect: meow
inspect: woof
```

and

Before:

```
p()

inspect:
```

After:

```
p()

<nothing, appropriately>
```
