### PR TITLE
fixes #638

### DIFF
--- a/lib/visitor/evaluator.js
+++ b/lib/visitor/evaluator.js
@@ -1,4 +1,3 @@
-
 /*!
  * Stylus - Evaluator
  * Copyright(c) 2010 LearnBoost <dev@learnboost.com>
@@ -594,7 +593,8 @@ Evaluator.prototype.visitIf = function(node){
 
 Evaluator.prototype.visitExtend = function(extend){
   var selector = extend.selector;
-  this.currentBlock.node.extends.push(selector);
+  if(this.targetBlock === undefined) this.currentBlock.node.extends.push(selector);
+  else this.targetBlock.node.extends.push(selector);
   return nodes.null; 
 };
 


### PR DESCRIPTION
fixes #638 where an `@extend` inside of a mixin does not work properly because `visitExtend` does not know where to push the selector
