### PR TITLE
Add reference to stylus plugin for Play 2.0

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -111,6 +111,7 @@ form input {
 ### Framework Support
 
    - [Connect](/LearnBoost/stylus/blob/master/docs/middleware.md)
+   - [Play! 2.0](https://github.com/knuton/play-stylus)
    - [Ruby On Rails](https://github.com/lucasmazza/ruby-stylus)
 
 ### CMS Support


### PR DESCRIPTION
The plugin adds support for stylus assets to Play 2.0 projects. It depends on the stylus executable to be installed.
