### PR TITLE
Simpler way to remove trailing zeros

### DIFF
--- a/lib/nodes/rgba.js
+++ b/lib/nodes/rgba.js
@@ -275,7 +275,7 @@ RGBA.prototype.toString = function(){
       + this.r + ','
       + this.g + ','
       + this.b + ','
-      + (+this.a.toFixed(3).toString()) + ')';
+      + (+this.a.toFixed(3)) + ')';
   }
 };
 


### PR DESCRIPTION
`toFixed()` already returns a string, so calling `toString()` is unnecessary.
