### PR TITLE
rgba() passed a single argument (i.e. #323232) should still work with al...

### DIFF
--- a/lib/functions/index.js
+++ b/lib/functions/index.js
@@ -73,7 +73,6 @@ var typeMap = {
  */
 
 exports.hsla = function hsla(hue, saturation, lightness, alpha){
-  if (alpha && '%' == alpha.type) alpha.val /= 100;
   switch (arguments.length) {
     case 1:
       utils.assertColor(hue);
@@ -83,6 +82,7 @@ exports.hsla = function hsla(hue, saturation, lightness, alpha){
       utils.assertType(saturation, 'unit', 'saturation');
       utils.assertType(lightness, 'unit', 'lightness');
       utils.assertType(alpha, 'unit', 'alpha');
+      if (alpha && '%' == alpha.type) alpha.val /= 100;
       return new nodes.HSLA(
           hue.val
         , saturation.val
@@ -236,7 +236,7 @@ exports.blue = function blue(color){
  *    rgba(255,0,0,1)
  *    // => #ff0000
  *
- *    rgba(#ffcc00, 0.5)
+ *    rgba(#ffcc00, 50%)
  *    // rgba(255,204,0,0.5)
  *
  * @param {Unit|RGBA|HSLA} red
@@ -248,7 +248,6 @@ exports.blue = function blue(color){
  */
 
 exports.rgba = function rgba(red, green, blue, alpha){
-  if (alpha && '%' == alpha.type) alpha.val /= 100;
   switch (arguments.length) {
     case 1:
       utils.assertColor(red);
@@ -262,6 +261,7 @@ exports.rgba = function rgba(red, green, blue, alpha){
       utils.assertColor(red);
       var color = red.rgba;
       utils.assertType(green, 'unit', 'alpha');
+      if ('%' == green.type) green.val /= 100;
       return new nodes.RGBA(
           color.r
         , color.g
@@ -275,6 +275,7 @@ exports.rgba = function rgba(red, green, blue, alpha){
       var r = '%' == red.type ? Math.round(red.val * 2.55) : red.val;
       var g = '%' == green.type ? Math.round(green.val * 2.55) : green.val;
       var b = '%' == blue.type ? Math.round(blue.val * 2.55) : blue.val;
+      if (alpha && '%' == alpha.type) alpha.val /= 100;
       return new nodes.RGBA(
           r
         , g

--- a/test/cases/literal.color.css
+++ b/test/cases/literal.color.css
@@ -11,4 +11,5 @@ body {
   color: rgba(3,3,3,0.75);
   color: rgba(50,50,50,0.75);
   color: rgba(50,50,50,0.75);
+  color: rgba(50,50,50,0.75);
 }

--- a/test/cases/literal.color.styl
+++ b/test/cases/literal.color.styl
@@ -11,3 +11,4 @@ body
   color: hsla(1,1,1,75%)
   color: rgba(50,50,50,0.75)
   color: rgba(50,50,50,75%)
+  color: rgba(#323232,75%)


### PR DESCRIPTION
...pha arguments of unit type %. i.e. rgba(#323232,75%) or rgba(50,50,50,75%) will both compile to rgba(50,50,50,0.75).

This is now possible:

```
rgba(#323232,75%) 
> rgba(50,50,50,0.75)
```
