### PR TITLE
Allow fade-out and fade-in to take % units; Add 2 new bifs for help in s...

### DIFF
--- a/lib/functions/index.styl
+++ b/lib/functions/index.styl
@@ -61,6 +61,22 @@ sum(nums)
 avg(nums)
   sum(nums) / length(nums)
 
+// return a unitless number, or pass through
+
+remove-unit(n)
+  if typeof(n) is "unit"
+    unit(n,"")
+  else
+    n
+
+// convert a percent to a decimal, or pass through
+
+percent-to-decimal(n)
+  if unit(n) is "%"
+    remove-unit(n)/100
+  else
+    n
+
 // color components
 
 alpha(color) { component(hsl(color), 'alpha') }
@@ -111,12 +127,12 @@ lighten(color, amount)
 // decerase opacity by amount
 
 fade-out(color, amount)
-  color - rgba(black, amount)
-
+  color - rgba(black, percent-to-decimal(amount))
+  
 // increase opacity by amount
 
 fade-in(color, amount)
-  color + rgba(black, amount)
+  color + rgba(black, percent-to-decimal(amount))
 
 // spin hue by a given amount
 

--- a/test/cases/bifs.fade.css
+++ b/test/cases/bifs.fade.css
@@ -4,3 +4,9 @@ body {
   color: #eee;
   color: rgba(238,238,238,0.4);
 }
+.test-percent-values {
+  color: rgba(238,238,238,0.8);
+  color: rgba(238,238,238,0.5);
+  color: #eee;
+  color: rgba(238,238,238,0.4);
+}

--- a/test/cases/bifs.fade.styl
+++ b/test/cases/bifs.fade.styl
@@ -4,3 +4,9 @@ body
   color: fade-out(#eee, .5)
   color: fade-in(rgba(#eee, .5), .5)
   color: fade-in(rgba(#eee, .2), .2)
+
+.test-percent-values
+  color: fade-out(#eee, 20%)
+  color: fade-out(#eee, 50%)
+  color: fade-in(rgba(#eee, 50%), 50%)
+  color: fade-in(rgba(#eee, 20%), 20%)

--- a/test/cases/bifs.percent-to-decimal.css
+++ b/test/cases/bifs.percent-to-decimal.css
@@ -1,0 +1,6 @@
+body {
+  opacity: 1;
+  opacity: 0.1;
+  opacity: 0;
+  opacity: 0.005;
+}

--- a/test/cases/bifs.percent-to-decimal.styl
+++ b/test/cases/bifs.percent-to-decimal.styl
@@ -1,0 +1,5 @@
+body
+  opacity: percent-to-decimal(100%)
+  opacity: percent-to-decimal(10%)
+  opacity: percent-to-decimal(0%)
+  opacity: percent-to-decimal(0.5%)

--- a/test/cases/bifs.remove-unit.css
+++ b/test/cases/bifs.remove-unit.css
@@ -1,0 +1,5 @@
+body {
+  line-height: 1;
+  line-height: auto;
+  line-height: 5;
+}

--- a/test/cases/bifs.remove-unit.styl
+++ b/test/cases/bifs.remove-unit.styl
@@ -1,0 +1,4 @@
+body
+  line-height remove-unit(1em)
+  line-height remove-unit(auto)
+  line-height remove-unit(5)


### PR DESCRIPTION
...imple math work as used in the new fade-out and fade-in bifs

This is now possible:

```
fade-in(rgba(#eee, 20%), 20%)
> rgba(238,238,238,0.4);
```
