### PR TITLE
Allow for more complex source and destination paths through middleware.

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -32,6 +32,8 @@ var imports = {};
  *    `src`       Source directory used to find .styl files
  *    `dest`      Destination directory used to output .css files
  *                when undefined defaults to `src`.
+ *    `base`      Base directory used when requesting .css files
+ *                when undefined defaults to `dest`.   
  *    `compile`   Custom compile function, accepting the arguments
  *                `(str, path)`.
  *    `compress`  Whether the output .css files should be compressed
@@ -95,6 +97,11 @@ module.exports = function(options){
     ? options.dest
     : src;
 
+// Default base dir to dest
+var base = options.base
+    ? options.base
+    : dest;
+
   // Default compile callback
   options.compile = options.compile || function(str, path){
     return stylus(str)
@@ -109,7 +116,7 @@ module.exports = function(options){
     if ('GET' != req.method && 'HEAD' != req.method) return next();
     var path = url.parse(req.url).pathname;
     if (/\.css$/.test(path)) {
-      var cssPath = join(dest, path)
+      var cssPath = join(base, path)
         , stylusPath = join(src, path.replace('.css', '.styl'));
 
       // Ignore ENOENT to fall through as 404


### PR DESCRIPTION
Support for a 'base' directory which is used to construct the path accessed via a request through through the middleware.

``` javascript
app.use(stylus.middleware({
    src: __dirname + '/views'
  , dest: __dirname + '/public/stylesheets'
  , base: __dirname + '/public'
  , compile: compile
}));
.
.
app.use(express.static(__dirname + '/public'));
```

given a main.styl file located in /views/stylesheets; can reference it via:

``` javascript
link(rel='stylesheet', href='/stylesheets/main.css')
```

These changes should not break any existing code.
