### PR TITLE
Fixes #676

### DIFF
--- a/lib/visitor/compiler.js
+++ b/lib/visitor/compiler.js
@@ -31,6 +31,7 @@ var Compiler = module.exports = function Compiler(root, options) {
   this.firebug = options.firebug;
   this.linenos = options.linenos;
   this.spaces = options['indent spaces'] || 2;
+  this.includeCSS = options['include css'];
   this.indents = 1;
   Visitor.call(this, root);
   this.stack = [];
@@ -132,6 +133,7 @@ Compiler.prototype.visitBlock = function(block){
         break;
       case 'media':
       case 'import':
+      case 'literal':
       case 'fontface':
         this.visit(node);
         break;
@@ -255,7 +257,15 @@ Compiler.prototype.visitCharset = function(charset){
  */
 
 Compiler.prototype.visitLiteral = function(lit){
-  return lit.val.trim().replace(/^  /gm, '');
+  var val = lit.val.trim();
+
+  if (!this.includeCSS) {
+    val = val.replace(/^  /gm, '');
+  } else {
+    this.buf += val + '\n';
+  }
+
+  return val;
 };
 
 /**

--- a/test/cases/import.include.css
+++ b/test/cases/import.include.css
@@ -1,0 +1,4 @@
+.c {
+  height: 100px;
+  background: #fff;
+}

--- a/test/cases/import.include.styl
+++ b/test/cases/import.include.styl
@@ -1,0 +1,1 @@
+@import "./import.include/a"

--- a/test/cases/import.include/a.styl
+++ b/test/cases/import.include/a.styl
@@ -1,0 +1,1 @@
+@import "nested/b"

--- a/test/cases/import.include/nested/b.styl
+++ b/test/cases/import.include/nested/b.styl
@@ -1,0 +1,1 @@
+@import "c.css"

--- a/test/cases/import.include/nested/c.css
+++ b/test/cases/import.include/nested/c.css
@@ -1,0 +1,4 @@
+.c {
+  height: 100px;
+  background: #fff;
+}

--- a/test/run.js
+++ b/test/run.js
@@ -29,6 +29,7 @@ describe('integration', function(){
         .define('url', stylus.url());
 
       if (~test.indexOf('compress')) style.set('compress', true);
+      if (~test.indexOf('include')) style.set('include css', true);
 
       style.render(function(err, actual){
         if (err) throw err;


### PR DESCRIPTION
 Stylus incorrectly imports the .css files that are not in the same folder as the processed .styl file.
