### PR TITLE
Normalize new lines at css import

### DIFF
--- a/lib/visitor/evaluator.js
+++ b/lib/visitor/evaluator.js
@@ -654,7 +654,7 @@ Evaluator.prototype.visitImport = function(imported){
   nodes.filename = found;
 
   var str = fs.readFileSync(found, 'utf8');
-  if (literal) return new nodes.Literal(str);
+  if (literal) return new nodes.Literal(str.replace(/\r\n?/g, "\n"));
 
   // parse
   var block = new nodes.Block


### PR DESCRIPTION
on windows

Tests fail because new lines do not match

```

  ? 1 of 214 tests failed:

  1) integration import include basic:

      actual expected

      body {
        background: red;
      }
```

with

```
actual = 'body {\r\n  background: red;\r\n}'
css    = 'body {\n  background: red;\n}'
```

This commit fixes it:

```
  .....................................................................................................................................................
  .................................................................

  ? 214 tests complete (5762ms)
```

You may test it on *nix systems again.
