### PR TITLE
Keep the importance modifier in CSS to Stylus convertor

### DIFF
--- a/lib/convert/css.js
+++ b/lib/convert/css.js
@@ -120,7 +120,7 @@ Converter.prototype.visitStyle = function(node){
   for (var i = 0, len = node.style.length; i < len; ++i) {
     var prop = node.style[i]
       , val = node.style[prop]
-      , importance = node.style['_importants'][node.style[i]] ? ' !important' : '';
+      , importance = node.style['_importants'][prop] ? ' !important' : '';
     if (prop) {
       buf += this.indent + prop + ': ' + val + importance + '\n';
     }


### PR DESCRIPTION
Right now the `!important` modifier from the original CSS file is lost when you convert it to stylus via `stylus --css`. This patch fixes it.
