### PR TITLE
Last rule is ignored when empty indents are at the end of the file.

### DIFF
--- a/lib/lexer.js
+++ b/lib/lexer.js
@@ -67,6 +67,7 @@ function Lexer(str, options) {
   };
 
   this.str = str
+    .replace(/\s+$/, '\n')
     .replace(/\r\n?/g, '\n')
     .replace(/\\ *\n/g, ' ')
     .replace(/([,:(]) *\n\s*/g, comment)

--- a/test/cases/whitespace.oes.css
+++ b/test/cases/whitespace.oes.css
@@ -1,0 +1,4 @@
+.myclass {
+  display: block;
+  color: #000;
+}

--- a/test/cases/whitespace.oes.styl
+++ b/test/cases/whitespace.oes.styl
@@ -1,0 +1,5 @@
+// Last line in this file has 4 spaces.
+.myclass
+  display block
+  color black
+    


### PR DESCRIPTION
Example:

```
// Last line in this file has 4 spaces.
.myclass
  display block
  color black

```

Produces:

```
.myclass {
  display: block;
}
```

Expected:

```
.myclass {
  display: block;
  color: #000;
}
```

This may happen while reorganizing the file. No warning is given, last rule is just silently ignored.
