### PR TITLE
Adding list of all css3 units

### DIFF
--- a/lib/units.js
+++ b/lib/units.js
@@ -5,22 +5,16 @@
  * MIT Licensed
  */
 
+// units found in http://www.w3.org/TR/css3-values
+
 module.exports = [
-    'em'
-  , 'ex'
-  , 'px'
-  , 'mm'
-  , 'cm'
-  , 'in'
-  , 'pt'
-  , 'pc'
-  , 'deg'
-  , 'rad'
-  , 'grad'
-  , 'ms'
-  , 's'
-  , 'Hz'
-  , 'kHz'
-  , 'rem'
-  , '%'
+    'em', 'ex', 'ch', 'rem' // relative lengths
+  , 'vw', 'vh', 'vmin' // relative viewport-percentage lengths
+  , 'cm', 'mm', 'in', 'pt', 'pc', 'px' // absolute lengths
+  , 'deg', 'grad', 'rad', 'turn' // angles
+  , 's', 'ms' // times
+  , 'Hz', 'kHz' // frequencies
+  , 'dpi', 'dpcm', 'dppx' // resolutions
+  , '%' // percentage type
+  , 'fr' // grid-layout (http://www.w3.org/TR/css3-grid-layout/)
 ];


### PR DESCRIPTION
Units defined per the following specifications:
- http://www.w3.org/TR/css3-values
- http://www.w3.org/TR/css3-grid-layout/

Units module seems to be missing a few units from the css3-values spec, plus fr from grid-layout.

The project I am working on uses stylus and we need support for grid layout (fr).
