### PR TITLE
Switch to fs.watch instead of fs.watchFile on Linux.

### DIFF
--- a/bin/stylus
+++ b/bin/stylus
@@ -10,6 +10,7 @@ var fs = require('fs')
   , dirname = require('path').dirname
   , resolve = require('path').resolve
   , join = require('path').join
+  , isLinux = process.platform === 'linux'
   , isWindows = process.platform === 'win32';
 
 /**
@@ -553,7 +554,7 @@ function watch(file, fn) {
   console.log('  \033[90mwatching\033[0m %s', file);
   // if is windows use fs.watch api instead
   // TODO: remove watchFile when fs.watch() works on osx etc
-  if (isWindows) {
+  if (isWindows || isLinux) {
     fs.watch(file, function(event) {
       if (event === 'change') fn(file);
     });


### PR DESCRIPTION
Fixes --watch on node.js 0.7.
