### PR TITLE
Remove Readme.md from .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -5,7 +5,6 @@
 
 History.md
 Makefile
-Readme.md
 
 docs/
 editors/


### PR DESCRIPTION
In order to get website goodness, searchability, and other forms of awesome,
you must include a readme file in your npm tarball.
