### PR TITLE
add missing space between "to" and "GitHub"

### DIFF
--- a/assets/index.jade
+++ b/assets/index.jade
@@ -110,7 +110,7 @@ html
           pre.terminal $ npm install stylus
           p
             | If you want an expressive css language for nodejs with these
-            | features or the features listed below, head over to
+            | features or the features listed below, head over to 
             a(href='http://github.com/learnboost/stylus') GitHub 
             | for more information.
           .features


### PR DESCRIPTION
Add missing space between "to" and "GitHub" in index.jade template
