### PR TITLE
Fix for issue #604

### DIFF
--- a/lib/visitor/compiler.js
+++ b/lib/visitor/compiler.js
@@ -479,7 +479,7 @@ Compiler.prototype.compileSelectors = function(arr){
 
 Compiler.prototype.debugInfo = function(node){
 
-  var path = fs.realpathSync(node.filename)
+  var path = node.filename == 'stdin' ? 'stdin' : fs.realpathSync(node.filename)
     , line = node.nodes ? node.nodes[0].lineno : node.lineno;
 
   if (this.linenos){


### PR DESCRIPTION
This is a fix for issue #604 which caused stylus to crash when using
--line-numbers or firebug and stein at the same time. This was caused
by trying to call fs.realpathSync with a bogus file named stdin.

https://github.com/LearnBoost/stylus/issues/604

Obviously there is no path to include in the line numbers when using stdin, so I just used 'stdin' as the path name and prevented the call to fs.realpathSync which was causing the crash.
