### PR TITLE
Writes css output to stdout if you pass the parameter --out stdout.

### DIFF
--- a/bin/stylus
+++ b/bin/stylus
@@ -525,6 +525,12 @@ function compileFile(file) {
  */
 
 function writeFile(file, css) {
+  if(dest === 'stdout') {
+    //  Write to stdout instead of file
+    console.log(css);
+    return;
+  }
+
   // --out support
   var path = dest
     ? join(dest, basename(file, '.styl') + '.css')


### PR DESCRIPTION
This change allows you to pass in a file, but instead of writing the .css to disk, it sends it to stdout. The usage is: `stylus --out stdout file.styl`. This is to get around the fact that paths are not available when using --line-numbers and sending in content via stdin. 

An alternative to this approach would be to add an option to override the path which is displayed in debug which may be a better approach since you could then use relative paths for the debug information.
