### PR TITLE
Test case for mixins passing keyword args correctly 

### DIFF
--- a/test/cases/mixin.pass-keyword-args.css
+++ b/test/cases/mixin.pass-keyword-args.css
@@ -1,0 +1,8 @@
+body {
+  background: #fff;
+  height: 100;
+}
+#content {
+  background: #fff;
+  height: 200;
+}

--- a/test/cases/mixin.pass-keyword-args.styl
+++ b/test/cases/mixin.pass-keyword-args.styl
@@ -1,0 +1,12 @@
+mixinA(height)
+  background: #fff
+  mixinB(height: height);
+
+mixinB(height = 0)
+  height: height
+
+body
+  mixinA(100)
+
+#content
+  mixinA(200)


### PR DESCRIPTION
#744 reported that mixins weren't correctly passing keyword args on to other mixins. Sometime in the last month this issue magically went away, so here's a test case to make sure this regression doesn't appear again.
