### PR TITLE
Support for @import of JSON variables

### DIFF
--- a/lib/visitor/evaluator.js
+++ b/lib/visitor/evaluator.js
@@ -645,7 +645,7 @@ Evaluator.prototype.visitImport = function(imported){
   }
 
   // support optional .styl
-  if (!literal && !~path.indexOf('.styl')) path += '.styl';
+  if (!literal && !~path.indexOf('.styl') && !~path.indexOf('.json')) path += '.styl';
 
   // Lookup
   found = utils.lookup(path, this.paths, this.filename);
@@ -666,6 +666,9 @@ Evaluator.prototype.visitImport = function(imported){
 
   var str = fs.readFileSync(found, 'utf8');
   if (literal) return new nodes.Literal(str.replace(/\r\n?/g, "\n"));
+
+  //support importing variables in JSON format
+  if(~path.indexOf('.json')) str = this.jsonToStylus(JSON.parse(str));
 
   // parse
   var block = new nodes.Block
@@ -1194,3 +1197,21 @@ Evaluator.prototype.__defineGetter__('currentScope', function(){
 Evaluator.prototype.__defineGetter__('currentFrame', function(){
   return this.stack.currentFrame;
 });
+
+/**
+ * Convert a JS object into a string containing valid stylus variables
+ * 
+ * @return {String}
+ * @api private
+*/
+Evaluator.prototype.jsonToStylus = function(obj, prefix){
+  prefix = prefix ? prefix + "-" : "";
+  var result = "";
+  for (var key in obj){
+    if(typeof obj[key] === "object"){
+      result += this.jsonToStylus(obj[key], prefix + key);
+    }
+    else result += prefix + key + ' = unquote("' + obj[key] + '")\n';
+  }
+  return result;
+}

--- a/test/cases/import.json.css
+++ b/test/cases/import.json.css
@@ -1,0 +1,11 @@
+@media screen and (min-width:1px) and (max-width:400px) {
+  body {
+    margin: 0;
+    color: #fff;
+  }
+}
+@media screen and (min-width:1501px) {
+  body {
+    -webkit-transition: width 1s ease-in;
+  }
+}

--- a/test/cases/import.json.styl
+++ b/test/cases/import.json.styl
@@ -1,0 +1,13 @@
+@import "import.json/variables.json"
+
+@media queries-small
+  body
+    //json variable
+    margin spacing
+    color #fff
+
+//nested json variable
+@media queries-large
+  body
+    //deep nested json variable
+    -webkit-transition animate-special-fluid

--- a/test/cases/import.json/variables.json
+++ b/test/cases/import.json/variables.json
@@ -1,0 +1,12 @@
+{
+  "spacing" : 0,
+  "queries": {
+    "small": "screen and (min-width:1px) and (max-width:400px)",
+    "large": "screen and (min-width:1501px)"
+  },
+  "animate": {
+    "special": {
+      "fluid": "width 1s ease-in"
+    }
+  }
+}


### PR DESCRIPTION
Sharing certain variables across JS and Stylus is crazy awesome. For example, store your media queries in queries.json, and bring them in with Stylus:

```
@import "queries.json"

@media large
  .main
    width: 100%
```

And use the same variables in your JS:

``` js
$.ajax({
  url: 'queries.json',
  method: 'GET',
  dataType: 'JSON',
  success: function(queries){
    var query = window.matchMedia(queries.large);
    handleChange(query); //initial match
    query.addListener(handleChange.bind(this, query)); //on query match change
  }
});

function handleChange(query){
  if(query.matches){
    //change img src to use large images
  }
}
```

They're really more of constants; changing them in JS won't affect the ones set in Stylus obviously. But still extremely useful (media query breakpoints, CSS transitions, etc).

Added new test, `import.json.styl`, all other tests still passing. If y'all dig it I can update the `import` docs page as well. 
