### PR TITLE
BIF for converting .json to Stylus variables

### DIFF
--- a/lib/functions/index.js
+++ b/lib/functions/index.js
@@ -13,7 +13,8 @@ var Compiler = require('../visitor/compiler')
   , nodes = require('../nodes')
   , utils = require('../utils')
   , Image = require('./image')
-  , path = require('path');
+  , path = require('path')
+  , fs = require('fs');
 
 /**
  * Color component name map.
@@ -373,6 +374,67 @@ exports.rgb = function rgb(red, green, blue){
         , green
         , blue
         , new nodes.Unit(1));
+  }
+};
+
+/**
+ * Convert a .json file into stylus variables
+ * Nested variable object keys are joined with a dash (-)
+ *
+ * Given this sample media-queries.json file:
+ * {
+ *   "small": "screen and (max-width:400px)",
+ *   "tablet": {
+ *     "landscape": "screen and (min-width:600px) and (orientation:landscape)",
+ *     "portrait": "screen and (min-width:600px) and (orientation:portrait)"
+ *   }
+ * }
+ *
+ * Examples:
+ *
+ *    json('media-queries.json')
+ *    
+ *    @media small
+ *    // => @media screen and (max-width:400px)
+ *
+ *    @media tablet-landscape
+ *    // => @media screen and (min-width:600px) and (orientation:landscape)
+ *       
+ * @param {String} path
+ * @api public
+*/
+
+exports.json = function(path){
+  var units = require('../units')
+  , found = utils.lookup(path.string, this.options.paths, this.options.filename);
+  if (!found) throw new Error('failed to locate .json file ' + path.string);
+  var str = fs.readFileSync(found, 'utf8');
+  convert.call(this, JSON.parse(str));
+  return nodes.null;
+
+  function convert(obj, prefix){
+    prefix = prefix ? prefix + "-" : "";
+    for (var key in obj){
+      var val = obj[key];
+      var name = prefix + key;
+      //recurse for nested objects
+      if(typeof val === "object") convert.call(this, val, name);
+      else {
+        val = utils.coerce(val);
+        if(val.nodeName === 'string') val = getUnit(val.string) || new nodes.Literal(val.string);
+        this.global.scope.add({name: name, val: val});
+      }
+    }
+  }
+  
+  //convert string (e.g. "40px") into a Unit
+  function getUnit(str){
+    var numbers = str.match(/[\d.]+/g);
+    if(numbers){
+      var lastNum = numbers.pop();
+      var rest = str.slice(str.lastIndexOf(lastNum) + lastNum.length);
+      if (units.indexOf(rest) !== -1) return new nodes.Unit(lastNum, rest);
+    }
   }
 };
 

--- a/test/cases/bifs.json.css
+++ b/test/cases/bifs.json.css
@@ -1,0 +1,14 @@
+@media screen and (min-width:1px) and (max-width:400px) {
+  body {
+    background: purple;
+    padding: 0;
+    outline: 0;
+    margin: 20px;
+    border: #f00;
+  }
+}
+@media screen and (min-width:1501px) {
+  body {
+    -webkit-transition: width 1s ease-out;
+  }
+}

--- a/test/cases/bifs.json.styl
+++ b/test/cases/bifs.json.styl
@@ -1,0 +1,19 @@
+json('import.json/vars.json')
+
+@media queries-small
+  body
+    //string variable
+    background bg
+    //number variable
+    padding spacing
+    //acts the same as regular variables
+    outline 1.5 * spacing
+    margin gutter * 2
+    if awesome
+      border red
+
+//nested json variable
+@media queries-large
+  body
+    //deep nested json variable
+    -webkit-transition animate-special-out

--- a/test/cases/import.json/vars.json
+++ b/test/cases/import.json/vars.json
@@ -1,0 +1,15 @@
+{
+  "bg" : "purple",
+  "spacing" : 0,
+  "gutter" : "10px",
+  "queries": {
+    "small": "screen and (min-width:1px) and (max-width:400px)",
+    "large": "screen and (min-width:1501px)"
+  },
+  "animate": {
+    "special": {
+      "out": "width 1s ease-out"
+    }
+  },
+  "awesome": true
+}


### PR DESCRIPTION
Sharing certain variables across JS and Stylus is crazy awesome. For example, store your media queries in queries.json, and bring them in with Stylus:

```
json("queries.json")

@media large
  .main
    width: 100%
```

And use the same variables in your JS:

``` js
$.ajax({
  url: 'queries.json',
  method: 'GET',
  dataType: 'JSON',
  success: function(queries){
    var query = window.matchMedia(queries.large);
    handleChange(query); //initial match
    query.addListener(handleChange.bind(this, query)); //on query match change
  }
});

function handleChange(query){
  if(query.matches){
    //change img src to use large images
  }
}
```

Reworked based on previous discussion (#781). 

The [getUnit](https://github.com/geddesign/stylus/blob/master/lib/functions/index.js#L430) function is a result of `utils.coerce()` not turning a string like "10px" into a Unit, which was causing that fun `cannot perform 10px * 2` error. `getUnit` might be useful elsewhere, let me know if you want it moved to `utils`.

Thanks!
