### PR TITLE
Allow to set the file size limit of image inlining to zero to inline all files

### DIFF
--- a/docs/functions.url.md
+++ b/docs/functions.url.md
@@ -12,10 +12,10 @@ The `.define(name, callback)` method assigned a JavaScript function that can be 
         .set('filename', __dirname + '/css/test.styl')
         .define('url', stylus.url())
         .render(function(err, css){
-    
+
         });
 
-For example, imagine our images live in `./public/images`.  We want to use `url(images/tobi.png)`.  We could pass `paths` our public directory, so that it becomes part of the lookup process. 
+For example, imagine our images live in `./public/images`.  We want to use `url(images/tobi.png)`.  We could pass `paths` our public directory, so that it becomes part of the lookup process.
 
 Likewise, if instead we wanted `url(tobi.png)`, we could pass `paths: [__dirname + '/public/images']`.
 
@@ -23,10 +23,10 @@ Likewise, if instead we wanted `url(tobi.png)`, we could pass `paths: [__dirname
         .set('filename', __dirname + '/css/test.styl')
         .define('url', stylus.url({ paths: [__dirname + '/public'] }))
         .render(function(err, css){
-          
+
         });
-  
+
 ### Options
 
-  - `limit` bytesize limit defaulting to 30Kb (30000)
+  - `limit` bytesize limit defaulting to 30Kb (30000), use `false` to disable the limit
   - `paths` image resolution path(s)

--- a/lib/functions/url.js
+++ b/lib/functions/url.js
@@ -51,24 +51,22 @@ var mimes = {
 module.exports = function(options) {
   options = options || {};
 
-  var sizeLimit = options.limit || 30000
-    , _paths = options.paths || [];
+  var _paths = options.paths || [];
 
-  function url(url){
+  function fn(url){
     // Compile the url
     var compiler = new Compiler(url);
     compiler.isURL = true;
-    var url = url.nodes.map(function(node){
+    url = url.nodes.map(function(node){
       return compiler.visit(node);
     }).join('');
 
-    // Parse literal 
-    var url = parse(url)
-      , ext = extname(url.pathname)
+    // Parse literal
+    url = parse(url)
+    var ext = extname(url.pathname)
       , mime = mimes[ext]
       , literal = new nodes.Literal('url("' + url.href + '")')
       , paths = _paths.concat(this.paths)
-      , founds
       , buf;
 
     // Not supported
@@ -87,12 +85,12 @@ module.exports = function(options) {
     buf = fs.readFileSync(found);
 
     // To large
-    if (buf.length > sizeLimit) return literal;
+    if ('number' == typeof options.limit && buf.length > options.limit) return literal;
 
     // Encode
     return new nodes.Literal('url("data:' + mime + ';base64,' + buf.toString('base64') + '")');
   };
 
-  url.raw = true;
-  return url;
+  fn.raw = true;
+  return fn;
 };


### PR DESCRIPTION
See the title :)

{limit: 0} will now inline all images.
