### PR TITLE
change polling intervall for watch.

### DIFF
--- a/bin/stylus
+++ b/bin/stylus
@@ -572,7 +572,7 @@ function watch(file, fn) {
       if (event === 'change') fn(file);
     });
   } else {
-    fs.watchFile(file, { interval: 50 }, function(curr, prev) {
+    fs.watchFile(file, { interval: 300 }, function(curr, prev) {
       if (curr.mtime > prev.mtime) fn(file);
     });
   }


### PR DESCRIPTION
50ms polling interval was very cpu intensive on vboxsf shared directory.
now it is 300ms, cpu is 5% instead of 30% and as a developer you would not feel much difference. 
it usually takes longer to switch to the browser and hit F5 ;)
