### PR TITLE
Fix broken 'limit' option for the url module

### DIFF
--- a/lib/functions/url.js
+++ b/lib/functions/url.js
@@ -52,7 +52,7 @@ module.exports = function(options) {
   options = options || {};
 
   var _paths = options.paths || [];
-  var sizeLimit = null != options.sizeLimit ? options.sizeLimit : 30000;
+  var sizeLimit = null != options.limit ? options.limit : 30000;
 
   function fn(url){
     // Compile the url


### PR DESCRIPTION
This was broken in https://github.com/LearnBoost/stylus/commit/61a2cfa1cf93fcb805ddbef1b3e76f9f585b77a0 where it was accidentally renamed to sizeLimit.
