### PR TITLE
make install-bundle fails if Bundles directory does not exist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ lib-cov: lib
 	jscoverage $< $@
 
 install-bundle:
+	mkdir -p $(TM_BUNDLE_DEST)
 	cp -fr $(TM_BUNDLE) $(TM_BUNDLE_DEST)
 
 update-bundle:


### PR DESCRIPTION
files were copied to a wrong location
