### PR TITLE
Fix @property lookup when a sibling is null

### DIFF
--- a/lib/visitor/evaluator.js
+++ b/lib/visitor/evaluator.js
@@ -1042,25 +1042,28 @@ Evaluator.prototype.lookup = function(name){
 
 Evaluator.prototype.interpolate = function(node){
   var self = this;
-  return node.segments.map(function(node){
-    function toString(node) {
-      switch (node.nodeName) {
-        case 'function':
-        case 'ident':
-          return node.name;
-        case 'literal':
-        case 'string':
-        case 'unit':
-          return node.val;
-        case 'expression':
-          self.return++;
-          var ret = toString(self.visit(node).first); 
-          self.return--;
-          return ret;
-      }
+  function toString(node) {
+    switch (node.nodeName) {
+      case 'function':
+      case 'ident':
+        return node.name;
+      case 'literal':
+      case 'string':
+      case 'unit':
+        return node.val;
+      case 'expression':
+        self.return++;
+        var ret = toString(self.visit(node).first);
+        self.return--;
+        return ret;
     }
+  }
+
+  if (node.segments) {
+    return node.segments.map(toString).join('');
+  } else {
     return toString(node);
-  }).join('');
+  }
 };
 
 /**

--- a/test/cases/property-access.siblings.styl
+++ b/test/cases/property-access.siblings.styl
@@ -17,4 +17,6 @@ body
 body
   foo: @bar == null
   bar: 'test'
+  unless true
+    bar: 'also test'
   baz: @bar


### PR DESCRIPTION
This can be seen in the wild when using nib > 0.4.1.

```
.clazz
  height 50px
  background-size 50px 50px
  margin-top @height
```
