### PR TITLE
Don't treat imported files that have `.css.` inside of the filename as literal CSS

### DIFF
--- a/lib/visitor/evaluator.js
+++ b/lib/visitor/evaluator.js
@@ -649,7 +649,7 @@ Evaluator.prototype.visitImport = function(imported){
   var name = path = path.string;
 
   // Literal
-  if (~path.indexOf('.css')) {
+  if (~path.indexOf('.css') && !~path.indexOf('.css.')) {
     literal = true;
     if (!includeCSS) return imported;
   }

--- a/test/cases/import.literal.css
+++ b/test/cases/import.literal.css
@@ -1,2 +1,5 @@
 @import "foo/bar.css";
 @import 'bar/baz.css';
+foo {
+  bar: baz;
+}

--- a/test/cases/import.literal.styl
+++ b/test/cases/import.literal.styl
@@ -1,3 +1,4 @@
 
 @import "foo/bar.css"
 @import 'bar/baz.css'
+@import 'import.literal/import.literal.css.styl'

--- a/test/cases/import.literal/import.literal.css.styl
+++ b/test/cases/import.literal/import.literal.css.styl
@@ -1,0 +1,2 @@
+foo
+  bar baz


### PR DESCRIPTION
There could be cases when the stylus file could have `.css.` inside of it, like `foo.css.styl`, and if we'd try to include it in other stylus file, then it'd be included as literal CSS. Such extensions are used in docpad or other generators with rails-like extension structure.

So, I've fixed it by adding a check on that, so if there would be a dot after `.css`, then Stylus wouldn't treat it as a literal CSS.

A test on that added and made sure all previous tests pass.
