### PR TITLE
Expose events explicitly fixes #897

### DIFF
--- a/lib/functions/url.js
+++ b/lib/functions/url.js
@@ -10,6 +10,7 @@
  */
 
 var Compiler = require('../visitor/compiler')
+  , events = require('../renderer').events
   , nodes = require('../nodes')
   , parse = require('url').parse
   , extname = require('path').extname
@@ -80,7 +81,14 @@ module.exports = function(options) {
     var found = utils.lookup(url.pathname, paths);
 
     // Failed to lookup
-    if (!found) return literal;
+    if (!found) {
+      events.emit(
+          'file not found'
+        , 'File ' + literal + ' could not be found, literal url retained!'
+      );
+
+      return literal;
+    }
 
     // Read data
     buf = fs.readFileSync(found);

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -14,6 +14,7 @@ var Parser = require('./parser')
   , Compiler = require('./visitor/compiler')
   , Evaluator = require('./visitor/evaluator')
   , Normalizer = require('./visitor/normalizer')
+  , events = new EventEmitter
   , utils = require('./utils')
   , nodes = require('./nodes')
   , path = require('path')
@@ -42,6 +43,7 @@ function Renderer(str, options) {
   options.filename = options.filename || 'stylus';
   this.options = options;
   this.str = str;
+  this.events = events;
 };
 
 /**
@@ -49,6 +51,12 @@ function Renderer(str, options) {
  */
 
 Renderer.prototype.__proto__ = EventEmitter.prototype;
+
+/**
+ * Expose events explicitly.
+ */
+
+module.exports.events = events;
 
 /**
  * Parse and evaluate AST, then callback `fn(err, css, js)`.


### PR DESCRIPTION
this should allow external programs to act upon events inside stylus, for example see: [square PR](https://github.com/observing/square/pull/48)

In addition to the exposed `file not found` this could be done for other events.
