### PR TITLE
MIddleware expects styl files to be in same directory as css files.

### DIFF
--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -37,7 +37,23 @@
             .set('warn', true)
             .set('compress', true);
         }
- 
+
+ Example:
+
+        styleLocation = join(__dirname + "/public")
+        cssLocation = join(__dirname + '/public')
+        console.log(styleLocation)
+        console.log(cssLocation)
+
+        connect.createServer(
+          stylus.middleware({ src: styleLocation, dest: cssLocation}),
+          connect.static(__dirname + '/public'),
+        ).listen 3000
+
+ This example expects the .styl files to be in the css directory. When the browser
+ requests /css/screen.css it will compile and serve a file from /css/screen.styl.
+ This is probably the simpliest configuration.
+
  Pass the middleware to Connect, grabbing `.styl` files from this directory
  and saving `.css` files to _./public_. Also supplying our custom `compile` function.
  


### PR DESCRIPTION
I was expecting to have a /styl directory and a /css directory.  The middleware expects that to be the same directory with the difference being the ext. I added an example to stress this.
