### PR TITLE
feature: allow blocking and css manipulation within 'end' event

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -76,8 +76,12 @@ Renderer.prototype.render = function(fn){
     var compiler = new Compiler(ast, this.options)
       , css = compiler.compile();
 
-    this.emit('end', css);
-    fn(null, css);
+    if (!this.listeners('end').length) {
+      return fn(null, css);
+    }
+    this.emit('end', css, function(err, css) {
+      fn(err, css);
+    });
   } catch (err) {
     var options = {};
     options.input = err.input || this.str;


### PR DESCRIPTION
my [stylus-lemonade](https://github.com/mikesmullin/stylus-lemonade) plugin necessarily makes two passes when pre-processing the stylus markup: 1) once during various calls to `define()` functions from within the `*.styl` stylesheets, and 2) again at the end once all the sprites that will be added have been added, so i can go back and update things like final dimensions and positions in the output sprite images.

the second pass is done via `emit('end')` event emitted during `stylus.render()`. this change request is to allow blocking during that event, and manipulation of the css result.
