### PR TITLE
middleware src & dest optionally as functions

### DIFF
--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -10,8 +10,10 @@
 #### Options
 
       `force`     When __true__ styles will always re-compile
-      `src`       Source directory used to find .styl files
-      `dest`      Destination directory used to output .css files
+      `src`       Source directory used to find .styl files,
+                  a string or function accepting `(path)` of request.
+      `dest`      Destination directory used to output .css files,
+                  a string or function accepting `(path)` of request,
                   when undefined defaults to `src`.
       `compress`  Whether the output .css files should be compressed
       `compile`   Custom compile function, accepting the arguments

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -29,8 +29,10 @@ var imports = {};
  * Options:
  *
  *    `force`     Always re-compile
- *    `src`       Source directory used to find .styl files
- *    `dest`      Destination directory used to output .css files
+ *    `src`       Source directory used to find .styl files,
+ *                a string or function accepting `(path)` of request.
+ *    `dest`      Destination directory used to output .css files,
+ *                a string or function accepting `(path)` of request,
  *                when undefined defaults to `src`.
  *    `compile`   Custom compile function, accepting the arguments
  *                `(str, path)`.
@@ -109,8 +111,13 @@ module.exports = function(options){
     if ('GET' != req.method && 'HEAD' != req.method) return next();
     var path = url.parse(req.url).pathname;
     if (/\.css$/.test(path)) {
-      var cssPath = join(dest, path)
-        , stylusPath = join(src, path.replace('.css', '.styl'));
+      var cssPath, stylusPath;
+      cssPath = (typeof dest == 'function')
+        ? dest(path)
+        : join(dest, path);
+      stylusPath = (typeof src == 'function')
+        ? src(path)
+        : join(src, path.replace('.css', '.styl'));
 
       // Ignore ENOENT to fall through as 404
       function error(err) {


### PR DESCRIPTION
See #210. This is a flexible solution that doesn't break the current API for string paths. It allows one to provide functions that return file paths given the request path. Usual case for these will involve some string replaces on the request path.

P.S. - How are you generating the markdown docs? Seems to come from the JSDoc-style annotations, but I didn't see any scripts.
