### PR TITLE
Fixes #444 - Allow unsuppressed comments in imports to be compiled

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -1113,7 +1113,6 @@ Parser.prototype = {
       group.push(new nodes.Selector(arr));
     } while (this.accept(',') || this.accept('newline'));
 
-    this.lexer.allowComments = false;
     this.state.push('selector');
     group.block = this.block(group);
     this.state.pop();

--- a/lib/visitor/compiler.js
+++ b/lib/visitor/compiler.js
@@ -137,6 +137,12 @@ Compiler.prototype.visitBlock = function(block){
       case 'fontface':
         this.visit(node);
         break;
+      case 'comment':
+        // only show comments inside when outside of scope and unsuppressed
+        if (!block.scope && !node.suppress) {
+          this.buf += this.visit(node) + '\n';
+        }
+        break;
       case 'literal':
         this.buf += this.visit(node) + '\n';
         break;

--- a/test/cases/import.comments.css
+++ b/test/cases/import.comments.css
@@ -1,0 +1,3 @@
+/*
+ * unsuppressed comment
+ */

--- a/test/cases/import.comments.styl
+++ b/test/cases/import.comments.styl
@@ -1,0 +1,1 @@
+@import "./import.comments/comments"

--- a/test/cases/import.comments/comments.styl
+++ b/test/cases/import.comments/comments.styl
@@ -1,0 +1,7 @@
+/*
+ * suppresed comment
+ */
+
+/*!
+ * unsuppressed comment
+ */


### PR DESCRIPTION
As mentioned in #444, imported comments are being ignored. This seems to be because imports are parsed as Block nodes, which have previously only compiled comments when properties were present. This fix adds comment compilation for Block nodes without properties as well, but only if the Block does not have scope (as is the case with an import). In order to prevent comments from existing plugins and libraries (like Nib) from being compiled, suppressed comments (without '!') are ignored.

Not sure if this is the best way to handle the problem, but it's fairly simple and seems to work well for me. I played with trying to use Root nodes for imports but ran into a lot of problems there. That said, I'd be happy to rework if there's a better way to solve this.
