### PR TITLE
stylus.url can now timestamp too large images

### DIFF
--- a/docs/functions.url.md
+++ b/docs/functions.url.md
@@ -1,6 +1,6 @@
 ## Data URI Image Inlining
 
-Stylus is bundled with an optional function named `url()`, which replaces the literal `url()` calls (and conditionally inlines them using base64 [Data URIs](http://en.wikipedia.org/wiki/Data_URI_scheme)).
+Stylus is bundled with an optional function named `url()`, which replaces the literal `url()` calls (and conditionally inlines them using base64 [Data URIs](http://en.wikipedia.org/wiki/Data_URI_scheme) or timestamps them).
 
 ### Example
 
@@ -15,7 +15,7 @@ The `.define(name, callback)` method assigned a JavaScript function that can be 
 
         });
 
-For example, imagine our images live in `./public/images`.  We want to use `url(images/tobi.png)`.  We could pass `paths` our public directory, so that it becomes part of the lookup process.
+For example, imagine our images live in `./public/images`. We want to use `url(images/tobi.png)`. We could pass `paths` our public directory, so that it becomes part of the lookup process.
 
 Likewise, if instead we wanted `url(tobi.png)`, we could pass `paths: [__dirname + '/public/images']`.
 
@@ -26,7 +26,10 @@ Likewise, if instead we wanted `url(tobi.png)`, we could pass `paths: [__dirname
 
         });
 
+By setting `timestamp` to `true` (defaults to `false`), images larger than `limit` (defaults to 30Kb) will be timestamped with a query string. Otherwise such files would just be skipped.
+
 ### Options
 
-  - `limit` bytesize limit defaulting to 30Kb (30000), use `false` to disable the limit
-  - `paths` image resolution path(s)
+  - `limit` bytesize limit defaulting to 30Kb
+  - `timestamp` if larger than `limit`, timestamp with a query string, defaulting to false
+  - `paths` image resolution path(s), merged with general lookup paths

--- a/lib/functions/url.js
+++ b/lib/functions/url.js
@@ -34,6 +34,7 @@ var mimes = {
  * Options:
  *
  *    - `limit` bytesize limit defaulting to 30Kb
+ *    - `timestamp` if larger than `limit`, timestamp with a query string, defaulting to false
  *    - `paths` image resolution path(s), merged with general lookup paths
  *
  * Examples:
@@ -53,6 +54,7 @@ module.exports = function(options) {
 
   var _paths = options.paths || [];
   var sizeLimit = null != options.limit ? options.limit : 30000;
+  var timestamp = options.timestamp || false;
 
   function fn(url){
     // Compile the url
@@ -86,7 +88,13 @@ module.exports = function(options) {
     buf = fs.readFileSync(found);
 
     // To large
-    if (false !== sizeLimit && buf.length > sizeLimit) return literal;
+    if (false !== sizeLimit && buf.length > sizeLimit) {
+      if (!timestamp) return literal;
+      
+      // Timestamp instead
+      var queryString = fs.statSync(found).mtime.getTime();
+      return new nodes.Literal('url("' + url.pathname + '?' + queryString + '")');
+    }
 
     // Encode
     return new nodes.Literal('url("data:' + mime + ';base64,' + buf.toString('base64') + '")');


### PR DESCRIPTION
If an image was considered too large to base 64 inline (according to `limit`), its url can be timestamped with a query string instead, so that larges files can be cached with a far-future expires header, but still be updated when modified (cache bust).

I added the logic, and documented it. I couldn't find how to write tests for it though.

Please tell me what you think, and what could be improved.
