### PR TITLE
Style guide parser for stylus

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -106,7 +106,7 @@ form input {
   - VIM [Syntax](https://github.com/wavded/vim-stylus)
   - [Firebug extension](/LearnBoost/stylus/blob/master/docs/firebug.md)
   - heroku [web service](http://styl.heroku.com) for compiling stylus
-  - [stylus guide](https://github.com/lepture/ganam) parser and generator
+  - [style guide](https://github.com/lepture/ganam) parser and generator
   - transparent vendor-specific function expansion
 
 ### Framework Support


### PR DESCRIPTION
I created a style guide parser and generator which supports stylus.

It is inspired by [kss](https://github.com/kneath/kss/issues/54).

A live preview:

[![Screen Shot 2013-01-08 at 8 11 27 PM](https://f.cloud.github.com/assets/290496/50049/8e4f0ad2-598f-11e2-8c7c-a811a425ea2a.png)](http://lab.lepture.com/ganam/guide/buttons)

Style guide syntax example: [buttons.styl](https://github.com/lepture/ganam/blob/master/docs/guide/buttons.styl).

Hope it can be listed in readme.
