### PR TITLE
Don't Evaluate Absolute URLs

### DIFF
--- a/lib/visitor/evaluator.js
+++ b/lib/visitor/evaluator.js
@@ -649,7 +649,7 @@ Evaluator.prototype.visitImport = function(imported){
   var name = path = path.string;
 
   // Absolute URL
-  if (path.substring(0, 9) === 'url("http') {
+  if (/url\s*\(\s*['"]http/i.test(path)) {
     return imported;
   }
 


### PR DESCRIPTION
Attempting to fix conflict between
`define('url', stylus.url())`
and
`@import url("http://fonts.googleapis.com/css?family=Lato:400,900&v2")`

LearnBoost/stylus#324

Could this change have any negative effects?  All tests still work after this change.
236 tests complete (6 seconds)
