### PR TITLE
Allow selector interpolation in @extend

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -1,4 +1,4 @@
- 
+
 /*!
  * Stylus - Parser
  * Copyright(c) 2010 LearnBoost <dev@learnboost.com>
@@ -113,31 +113,31 @@ var Parser = module.exports = function Parser(str, options) {
  */
 
 Parser.prototype = {
-  
+
   /**
    * Constructor.
    */
-  
+
   constructor: Parser,
-  
+
   /**
    * Return current state.
    *
    * @return {String}
    * @api private
    */
-  
+
   currentState: function() {
     return this.state[this.state.length - 1];
   },
-  
+
   /**
    * Parse the input, then return the root node.
    *
    * @return {Node}
    * @api private
    */
-  
+
   parse: function(){
     var block = this.parent = this.root;
     while ('eos' != this.peek().type) {
@@ -149,14 +149,14 @@ Parser.prototype = {
     }
     return block;
   },
-  
+
   /**
    * Throw an `Error` with the given `msg`.
    *
    * @param {String} msg
    * @api private
    */
-  
+
   error: function(msg){
     var type = this.peek().type
       , val = undefined == this.peek().val
@@ -165,7 +165,7 @@ Parser.prototype = {
     if (val.trim() == type.trim()) val = '';
     throw new errors.ParseError(msg.replace('{peek}', '"' + type + val + '"'));
   },
-  
+
   /**
    * Accept the given token `type`, and return it,
    * otherwise return `undefined`.
@@ -195,14 +195,14 @@ Parser.prototype = {
     }
     return this.next();
   },
-  
+
   /**
    * Get the next token.
    *
    * @return {Token}
    * @api private
    */
-  
+
   next: function() {
     var tok = this.stash.length
       ? this.stash.pop()
@@ -211,18 +211,18 @@ Parser.prototype = {
     debug.lexer('%s %s', tok.type, tok.val || '');
     return tok;
   },
-  
+
   /**
    * Peek with lookahead(1).
    *
    * @return {Token}
    * @api private
    */
-  
+
   peek: function() {
     return this.lexer.peek();
   },
-  
+
   /**
    * Lookahead `n` tokens.
    *
@@ -230,19 +230,19 @@ Parser.prototype = {
    * @return {Token}
    * @api private
    */
-  
+
   lookahead: function(n){
     return this.lexer.lookahead(n);
   },
-  
+
   /**
-   * Check if the token at `n` is a valid selector token. 
+   * Check if the token at `n` is a valid selector token.
    *
    * @param {Number} n
    * @return {Boolean}
    * @api private
    */
-  
+
   isSelectorToken: function(n) {
     var la = this.lookahead(n).type;
     switch (la) {
@@ -258,7 +258,7 @@ Parser.prototype = {
         return ~selectorTokens.indexOf(la);
     }
   },
-  
+
   /**
    * Check if the token at `n` is a pseudo selector.
    *
@@ -266,7 +266,7 @@ Parser.prototype = {
    * @return {Boolean}
    * @api private
    */
-  
+
   isPseudoSelector: function(n){
     return ~pseudoSelectors.indexOf(this.lookahead(n).val.name);
   },
@@ -288,11 +288,11 @@ Parser.prototype = {
       if (type == la.type) return true;
     }
   },
-  
+
   /**
    * Valid selector tokens.
    */
-  
+
   selectorToken: function() {
     if (this.isSelectorToken(1)) {
       if ('{' == this.peek().type) {
@@ -313,7 +313,7 @@ Parser.prototype = {
       return this.next();
     }
   },
-  
+
   /**
    * Consume whitespace.
    */
@@ -335,12 +335,12 @@ Parser.prototype = {
   /**
    * Consume spaces.
    */
-  
+
   skipSpaces: function() {
     while ('space' == this.peek().type)
       this.next();
   },
-  
+
   /**
    * Check if the following sequence of tokens
    * forms a function definition, ie trailing
@@ -351,12 +351,12 @@ Parser.prototype = {
     return 'indent' == this.lookahead(i).type
       || '{' == this.lookahead(i).type;
   },
-  
+
   /**
    * Check if the following sequence of tokens
    * forms a selector.
    */
-  
+
   looksLikeSelector: function() {
     var i = 1
       , brace;
@@ -455,7 +455,7 @@ Parser.prototype = {
    * | statement 'if' expression
    * | statement 'unless' expression
    */
-  
+
   statement: function() {
     var stmt = this.stmt()
       , state = this.prevState
@@ -504,7 +504,7 @@ Parser.prototype = {
 
     return stmt;
   },
-  
+
   /**
    *    ident
    *  | selector
@@ -522,7 +522,7 @@ Parser.prototype = {
    *  | expression
    *  | 'return' expression
    */
-  
+
   stmt: function() {
     var type = this.peek().type;
     switch (type) {
@@ -579,7 +579,7 @@ Parser.prototype = {
         return expr;
     }
   },
-  
+
   /**
    * indent (!outdent)+ outdent
    */
@@ -644,7 +644,7 @@ Parser.prototype = {
   /**
    * for val (',' key) in expr
    */
-  
+
   for: function() {
     this.expect('for');
     var key
@@ -657,11 +657,11 @@ Parser.prototype = {
     this.state.pop();
     return each;
   },
-  
+
   /**
    * return expression
    */
-  
+
   return: function() {
     this.expect('return');
     var expr = this.expression();
@@ -669,11 +669,11 @@ Parser.prototype = {
       ? new nodes.Return
       : new nodes.Return(expr);
   },
-  
+
   /**
    * unless expression block
    */
-  
+
   unless: function() {
     this.expect('unless');
     var node = new nodes.If(this.expression(), true);
@@ -682,7 +682,7 @@ Parser.prototype = {
     this.state.pop();
     return node;
   },
-  
+
   /**
    * if expression block (else block)?
    */
@@ -721,14 +721,18 @@ Parser.prototype = {
    */
 
   extend: function(){
-    var val = this.expect('extend').val;
-    return new nodes.Extend(val);
+    var val = this.expect('extend').val
+      , arr = this.selectorParts();
+
+    arr.unshift(new nodes.Literal(val));
+
+    return new nodes.Extend(new nodes.Selector(arr));
   },
 
   /**
    * media
    */
-  
+
   media: function() {
     var val = this.expect('media').val
       , media = new nodes.Media(val);
@@ -754,7 +758,7 @@ Parser.prototype = {
   /**
    * fontface
    */
-  
+
   fontface: function() {
     this.expect('font-face');
     var node = new nodes.FontFace;
@@ -767,24 +771,24 @@ Parser.prototype = {
   /**
    * import expression
    */
-   
+
   import: function() {
     this.expect('import');
     this.allowPostfix = true;
     return new nodes.Import(this.expression());
   },
-  
+
   /**
    * charset string
    */
-  
+
   charset: function() {
     this.expect('charset');
     var str = this.expect('string').val;
     this.allowPostfix = true;
     return new nodes.Charset(str);
   },
-  
+
   /**
    * page selector? block
    */
@@ -810,7 +814,7 @@ Parser.prototype = {
    *  (',' (unit | from | to)*)
    *  block)+
    */
-   
+
   keyframes: function() {
     var pos
       , tok = this.expect('keyframes')
@@ -871,32 +875,32 @@ Parser.prototype = {
 
     return keyframes;
   },
-  
+
   /**
    * literal
    */
-  
+
   literal: function() {
     return this.expect('literal').val;
   },
-  
+
   /**
    * ident space?
    */
-  
+
   id: function() {
     var tok = this.expect('ident');
     this.accept('space');
     return tok.val;
   },
-  
+
   /**
    *   ident
    * | assignment
    * | property
    * | selector
    */
-  
+
   ident: function() {
     var i = 2
       , la = this.lookahead(i).type;
@@ -992,11 +996,11 @@ Parser.prototype = {
         }
     }
   },
-  
+
   /**
    * '*'? (ident | '{' expression '}')+
    */
-  
+
   interpolate: function() {
     var node
       , segs = []
@@ -1022,7 +1026,7 @@ Parser.prototype = {
     if (!segs.length) this.expect('ident');
     return segs;
   },
-  
+
   /**
    *   property ':'? expression
    * | ident
@@ -1053,7 +1057,7 @@ Parser.prototype = {
 
     return ret;
   },
-  
+
   /**
    *   selector ',' selector
    * | selector newline selector
@@ -1061,52 +1065,16 @@ Parser.prototype = {
    */
 
   selector: function() {
-    var tok
-      , arr
+    var arr
       , group = new nodes.Group
       , scope = this.selectorScope
       , isRoot = 'root' == this.currentState();
 
     do {
-      arr = [];
-
       // Clobber newline after ,
       this.accept('newline');
 
-      // Selector candidates,
-      // stitched together to
-      // form a selector.
-      while (tok = this.selectorToken()) {
-        debug.selector('%s', tok);
-        // Selector component
-        switch (tok.type) {
-          case '{':
-            this.skipSpaces();
-            var expr = this.expression();
-            this.skipSpaces();
-            this.expect('}');
-            arr.push(expr);
-            break;
-          case 'comment':
-            arr.push(new nodes.Literal(tok.val.str));
-            break;
-          case 'color':
-            arr.push(new nodes.Literal(tok.val.raw));
-            break;
-          case 'space':
-            arr.push(new nodes.Literal(' '));
-            break;
-          case 'function':
-            arr.push(new nodes.Literal(tok.val.name + '('));
-            break;
-          case 'ident':
-            arr.push(new nodes.Literal(tok.val.name));
-            break;
-          default:
-            arr.push(new nodes.Literal(tok.val));
-            if (tok.space) arr.push(new nodes.Literal(' '));
-        }
-      }
+      arr = this.selectorParts();
 
       // Push the selector
       if (isRoot && scope) arr.unshift(new nodes.Literal(scope + ' '));
@@ -1117,14 +1085,55 @@ Parser.prototype = {
     group.block = this.block(group);
     this.state.pop();
 
-
     return group;
   },
-  
+
+  selectorParts: function(){
+    var tok
+      , arr = [];
+
+    // Selector candidates,
+    // stitched together to
+    // form a selector.
+    while (tok = this.selectorToken()) {
+      debug.selector('%s', tok);
+      // Selector component
+      switch (tok.type) {
+        case '{':
+          this.skipSpaces();
+          var expr = this.expression();
+          this.skipSpaces();
+          this.expect('}');
+          arr.push(expr);
+          break;
+        case 'comment':
+          arr.push(new nodes.Literal(tok.val.str));
+          break;
+        case 'color':
+          arr.push(new nodes.Literal(tok.val.raw));
+          break;
+        case 'space':
+          arr.push(new nodes.Literal(' '));
+          break;
+        case 'function':
+          arr.push(new nodes.Literal(tok.val.name + '('));
+          break;
+        case 'ident':
+          arr.push(new nodes.Literal(tok.val.name));
+          break;
+        default:
+          arr.push(new nodes.Literal(tok.val));
+          if (tok.space) arr.push(new nodes.Literal(' '));
+      }
+    }
+
+    return arr;
+  },
+
   /**
    * ident ('=' | '?=') expression
    */
-  
+
   assignment: function() {
     var op
       , node
@@ -1162,12 +1171,12 @@ Parser.prototype = {
 
     return node;
   },
-  
+
   /**
    *   definition
    * | call
    */
-  
+
   function: function() {
     var parens = 1
       , i = 2
@@ -1190,7 +1199,7 @@ Parser.prototype = {
           this.error('failed to find closing paren ")"');
       }
     }
-    
+
     // Definition or call
     switch (this.currentState()) {
       case 'expression':
@@ -1218,7 +1227,7 @@ Parser.prototype = {
   /**
    * ident '(' expression ')'
    */
-  
+
   functionCall: function() {
     if ('url' == this.peek().val.name) return this.url();
     var name = this.expect('function').val.name;
@@ -1230,11 +1239,11 @@ Parser.prototype = {
     this.state.pop();
     return new nodes.Call(name, args);
   },
-  
+
   /**
    * ident '(' params ')' block
    */
-  
+
   functionDefinition: function() {
     var name = this.expect('function').val.name;
 
@@ -1253,14 +1262,14 @@ Parser.prototype = {
     this.state.pop();
     return new nodes.Ident(name, fn);
   },
-  
+
   /**
    *   ident
    * | ident '...'
    * | ident '=' expression
    * | ident ',' ident
    */
-  
+
   params: function() {
     var tok
       , node
@@ -1279,7 +1288,7 @@ Parser.prototype = {
     }
     return params;
   },
-  
+
   /**
    * (ident ':')? expression (',' (ident ':')? expression)*
    */
@@ -1302,7 +1311,7 @@ Parser.prototype = {
 
     return args;
   },
- 
+
   /**
    * expression (',' expression)*
    */
@@ -1321,7 +1330,7 @@ Parser.prototype = {
     }
     return node;
   },
-  
+
   /**
    * negation+
    */
@@ -1337,23 +1346,23 @@ Parser.prototype = {
     this.state.pop();
     return expr;
   },
-  
+
   /**
    *   'not' ternary
    * | ternary
    */
-  
+
   negation: function() {
     if (this.accept('not')) {
       return new nodes.UnaryOp('!', this.negation());
     }
     return this.ternary();
   },
-  
+
   /**
    * logical ('?' expression ':' expression)?
    */
-  
+
   ternary: function() {
     var node = this.logical();
     if (this.accept('?')) {
@@ -1364,11 +1373,11 @@ Parser.prototype = {
     }
     return node;
   },
-  
+
   /**
    * typecheck (('&&' | '||') typecheck)*
    */
-  
+
   logical: function() {
     var op
       , node = this.typecheck();
@@ -1377,11 +1386,11 @@ Parser.prototype = {
     }
     return node;
   },
-  
+
   /**
    * equality ('is a' equality)*
    */
-  
+
   typecheck: function() {
     var op
       , node = this.equality();
@@ -1393,11 +1402,11 @@ Parser.prototype = {
     }
     return node;
   },
-  
+
   /**
    * in (('==' | '!=') in)*
    */
-  
+
   equality: function() {
     var op
       , node = this.in();
@@ -1424,15 +1433,15 @@ Parser.prototype = {
     }
     return node;
   },
-  
+
   /**
    * range (('>=' | '<=' | '>' | '<') range)*
    */
-  
+
   relational: function() {
     var op
       , node = this.range();
-    while (op = 
+    while (op =
          this.accept('>=')
       || this.accept('<=')
       || this.accept('<')
@@ -1445,11 +1454,11 @@ Parser.prototype = {
     }
     return node;
   },
-  
+
   /**
    * additive (('..' | '...') additive)*
    */
-  
+
   range: function() {
     var op
       , node = this.additive();
@@ -1461,11 +1470,11 @@ Parser.prototype = {
     }
     return node;
   },
-  
+
   /**
    * multiplicative (('+' | '-') multiplicative)*
    */
-  
+
   additive: function() {
     var op
       , node = this.multiplicative();
@@ -1476,11 +1485,11 @@ Parser.prototype = {
     }
     return node;
   },
-  
+
   /**
    * defined (('**' | '*' | '/' | '%') defined)*
    */
-  
+
   multiplicative: function() {
     var op
       , node = this.defined();
@@ -1502,12 +1511,12 @@ Parser.prototype = {
     }
     return node;
   },
-  
+
   /**
    *    unary 'is defined'
    *  | unary
    */
-  
+
   defined: function() {
     var node = this.unary();
     if (this.accept('is defined')) {
@@ -1516,12 +1525,12 @@ Parser.prototype = {
     }
     return node;
   },
-  
+
   /**
    *   ('!' | '~' | '+' | '-') unary
    * | subscript
    */
-  
+
   unary: function() {
     var op
       , node;
@@ -1537,12 +1546,12 @@ Parser.prototype = {
     }
     return this.subscript();
   },
-  
+
   /**
    *   primary ('[' expression ']' '='?)+
    * | primary
    */
-  
+
   subscript: function() {
     var node = this.primary();
     while (this.accept('[')) {
@@ -1556,7 +1565,7 @@ Parser.prototype = {
     }
     return node;
   },
-  
+
   /**
    *   unit
    * | null

--- a/lib/visitor/evaluator.js
+++ b/lib/visitor/evaluator.js
@@ -112,10 +112,10 @@ Evaluator.prototype.setup = function(){
 
 /**
  * Populate the global scope with:
- * 
+ *
  *   - css colors
  *   - user-defined globals
- * 
+ *
  * @api private
  */
 
@@ -382,7 +382,7 @@ Evaluator.prototype.visitIdent = function(ident){
   } else if (ident.val.isNull) {
     var val = this.lookup(ident.name);
     return val ? this.visit(val) : ident;
-  // Assign  
+  // Assign
   } else {
     this.return++;
     ident.val = this.visit(ident.val);
@@ -595,7 +595,7 @@ Evaluator.prototype.visitIf = function(node){
             ret = this.visit(elses[i].block);
             break;
           }
-        // else 
+        // else
         } else {
           ret = this.visit(elses[i]);
         }
@@ -617,7 +617,7 @@ Evaluator.prototype.visitIf = function(node){
  */
 
 Evaluator.prototype.visitExtend = function(extend){
-  var selector = extend.selector;
+  var selector = this.interpolate(extend.selector);
   var block = !this.currentBlock.node.extends && this.targetBlock.node.extends ? this.targetBlock : this.currentBlock;
   block.node.extends.push(selector);
   return nodes.null;

--- a/test/cases/extend.using-variable.css
+++ b/test/cases/extend.using-variable.css
@@ -1,0 +1,4 @@
+.test,
+.test2 {
+  width: 100%;
+}

--- a/test/cases/extend.using-variable.styl
+++ b/test/cases/extend.using-variable.styl
@@ -1,0 +1,7 @@
+.test
+  width 100%
+
+var = "test"
+
+.{var}2
+  @extend .{var}


### PR DESCRIPTION
As the title says, selector interpolation within the `@extend` statement was a feature I find needing every now and then. This is my first time touching a parser, etc. - so let me know if there are any issues. Added a small test case as well.

Should fix #564 as well. I do intend to also take a look at extending within loops as well, if no one else is already fixing this.
