### PR TITLE
Fixes @extend within a loop

### DIFF
--- a/lib/visitor/normalizer.js
+++ b/lib/visitor/normalizer.js
@@ -100,7 +100,7 @@ Normalizer.prototype.visitBlock = function(block){
           continue;
         default:
           ret.push(this.visit(node));
-      } 
+      }
     }
   }
 
@@ -173,7 +173,7 @@ Normalizer.prototype.visitMedia = function(media){
     var propertyGroup = new nodes.Group;
     propertyGroup.lineno = media.lineno;
     propertyGroup.filename = media.filename;
-    
+
     var propertyBlock = new nodes.Block(media.block, propertyGroup);
     propertyBlock.lineno = media.lineno;
     propertyBlock.filename = media.filename;
@@ -207,7 +207,7 @@ Normalizer.prototype.extend = function(group, selectors){
   var map = this.map
     , self = this;
 
-  group.extends.forEach(function(extend){
+  group.block.node.extends.forEach(function(extend){
     var groups = map[extend];
     if (!groups) throw new Error('Failed to @extend "' + extend + '"');
     selectors.forEach(function(selector){

--- a/test/cases/extend.in-loop.css
+++ b/test/cases/extend.in-loop.css
@@ -1,0 +1,7 @@
+.span,
+.span1,
+.span2,
+.span3,
+.span4 {
+  width: 100%;
+}

--- a/test/cases/extend.in-loop.styl
+++ b/test/cases/extend.in-loop.styl
@@ -1,0 +1,6 @@
+.span
+  width 100%
+
+for i in 1..4
+  .span{i}
+    @extend .span


### PR DESCRIPTION
This simple change fixes @extend within a loop. It may introduce another bug when combined with the interpolated extend selector - so if someone understands the scoping in Stylus and could help fix this issue properly, that would be awesome.

I also added a simple test case for it. Should also close #564, #939 and #953
