### PR TITLE
Allow @extend within media queries

### DIFF
--- a/lib/visitor/normalizer.js
+++ b/lib/visitor/normalizer.js
@@ -150,12 +150,14 @@ Normalizer.prototype.visitMedia = function(media){
     , other = [];
 
   media.block.nodes.forEach(function(node, i) {
+    node = this.visit(node);
+
     if ('property' == node.nodeName) {
       props.push(node);
     } else {
       other.push(node);
     }
-  });
+  }, this);
 
   // Fake self-referencing group to contain
   // any props that are floating

--- a/test/cases/extend.in-media-query.css
+++ b/test/cases/extend.in-media-query.css
@@ -1,0 +1,6 @@
+@media (min-width: 40em) {
+  .test,
+  .test-extend {
+    width: 100%;
+  }
+}

--- a/test/cases/extend.in-media-query.styl
+++ b/test/cases/extend.in-media-query.styl
@@ -1,0 +1,5 @@
+@media (min-width: 40em)
+  .test
+    width: 100%
+  .test-extend
+    @extend .test


### PR DESCRIPTION
Adding the ability to use `@extend` within a media query. Will extend anything within the same media query as well as outside the scope. Might close #902, except I am not sure if that pull request expects the behaviour of extending outside the media query.
