### PR TITLE
Fix for Windows where absolute path starts with two leading backslashes

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -21,8 +21,9 @@ var nodes = require('./nodes')
  * @api private
  */
 
-exports.absolute = function(path){
-  return /^([a-z]:\\)|\//i.test(path);
+exports.absolute = function(path){  
+  // On Windows the path could start with a drive letter, i.e. a:\\ or two leading backslashes
+  return path.substr(0, 2) == '\\\\' || path[0] == '/' || /^[a-z]:\\/i.test(path);
 };
 
 /**


### PR DESCRIPTION
The fix to issue #356 solved the error on Windows when the absolute path starts with a drive letter, however sometimes Windows also uses two leading backslashes for an absolute path. I noticed this is the case when running node.js on the Azure platform. The fix is to simply check for all 3 patterns in the absolute function in utils.js.

https://github.com/LearnBoost/stylus/issues/356
