### PR TITLE
Store mtime for literal imports

### DIFF
--- a/lib/visitor/evaluator.js
+++ b/lib/visitor/evaluator.js
@@ -690,6 +690,11 @@ Evaluator.prototype.visitImport = function(imported){
   // Expose imports
   imported.path = found;
   imported.dirname = dirname(found);
+  // Store the modified time
+  fs.stat(found, function(err, stat){
+    if (err) return;
+    imported.mtime = stat.mtime;
+  });
   this.paths.push(imported.dirname);
 
   // Nested imports
@@ -719,12 +724,6 @@ Evaluator.prototype.visitImport = function(imported){
     err.input = str;
     throw err;
   }
-
-  // Store the modified time
-  fs.stat(found, function(err, stat){
-    if (err) return;
-    imported.mtime = stat.mtime;
-  });
 
   // Evaluate imported "root"
   block.parent = root;


### PR DESCRIPTION
With the `include css` option set to `true`, the middleware always consider any css as modified. This pull request fixes it.
