### PR TITLE
Use monospace for code

### DIFF
--- a/main.css
+++ b/main.css
@@ -121,7 +121,7 @@ pre {
   width: 320px;
   padding: 30px;
   color: #8d8d8d;
-  font: 12px/1.4 monaco, 'helvetica neue', helvetica;
+  font: 12px/1.4 monaco, monospace;
   overflow-x: auto;
   background: #fff;
   -webkit-border-radius: 5px;


### PR DESCRIPTION
Please use monospace font for code listings. Using helvetica if monaco is not available is not ideal.

http://www.johndcook.com/blog/2013/03/12/use-typewriter-font-for-code-inside-prose/
