### PR TITLE
provide browserify compatibility

### DIFF
--- a/index-browserify.js
+++ b/index-browserify.js
@@ -1,2 +1,0 @@
-
-module.exports = require('./lib/stylus');

--- a/lib/browserify.js
+++ b/lib/browserify.js
@@ -1,0 +1,2 @@
+
+module.exports = require('./stylus');

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   , "keywords": ["css", "parser", "style", "stylesheets", "jade", "language"]
   , "repository": "git://github.com/learnboost/stylus"
   , "main": "./index.js"
-  , "browserify": "index-browserify.js"
+  , "browserify": "./lib/browserify.js"
   , "engines": { "node": "*" }
   , "bin": { "stylus": "./bin/stylus" }
   , "scripts" : { "prepublish" : "npm prune", "test": "make test" }


### PR DESCRIPTION
this makes a browserify compatible index.js and specifies it in the package.json.

In the browser I had to turn off imports to use it, like so:
var stylus = require('stylus');
stylus('...').set('imports', []).render(...);
