### PR TITLE
Added $hidden selectors that can be @extended but don't appear in rendered CSS

### DIFF
--- a/lib/visitor/compiler.js
+++ b/lib/visitor/compiler.js
@@ -89,7 +89,7 @@ Compiler.prototype.visitRoot = function(block){
 Compiler.prototype.visitBlock = function(block){
   var node;
 
-  if (block.hasProperties) {
+  if (block.hasProperties && !block.lacksRenderedSelectors) {
     var arr = [this.compress ? '{' : ' {'];
     ++this.indents;
     for (var i = 0, len = block.nodes.length; i < len; ++i) {
@@ -343,7 +343,10 @@ Compiler.prototype.visitGroup = function(group){
   // selectors
   if (group.block.hasProperties) {
     var selectors = this.compileSelectors(stack);
-    this.buf += (this.selector = selectors.join(this.compress ? ',' : ',\n'));
+    if(selectors.length)
+      this.buf += (this.selector = selectors.join(this.compress ? ',' : ',\n'));
+    else
+      group.block.lacksRenderedSelectors = true;
   }
 
   // output block
@@ -458,7 +461,8 @@ Compiler.prototype.compileSelectors = function(arr){
   var stack = this.stack
     , self = this
     , selectors = []
-    , buf = [];
+    , buf = []
+    , hiddenSelectorRegexp = /^\s*\$/;
 
   function interpolateParent(selector, buf) {
     var str = selector.val.trim();
@@ -477,6 +481,7 @@ Compiler.prototype.compileSelectors = function(arr){
   function compile(arr, i) {
     if (i) {
       arr[i].forEach(function(selector){
+        if(selector.val.match(hiddenSelectorRegexp)) return;
         if (selector.inherits) {
           buf.unshift(selector.val);
           compile(arr, i - 1);
@@ -487,6 +492,7 @@ Compiler.prototype.compileSelectors = function(arr){
       });
     } else {
       arr[0].forEach(function(selector){
+        if(selector.val.match(hiddenSelectorRegexp)) return;
         var str = interpolateParent(selector, buf);
         selectors.push(self.indent + str.trimRight());
       });


### PR DESCRIPTION
This is inspired by SASS's "hidden classes" feature, which I learned about by reading these slides: https://speakerdeck.com/anotheruiguy/sass-32-silent-classes

In SASS, hidden classes are prefixed by a `%` instead of a `.`.  I chose to use `$` because `%` is a Stylus operator and was throwing parsing errors.

Any selector starting with "$" is hidden (e.g. $foo) but can be still be @extend-ed.

**This Stylus:**

```
$ugly-button
    border 1px solid black

$ugly-red-button
    @extend $ugly-button
    background red

// This selector is never used; it's properties won't appear in the output
$ugly-blue-button
    @extend $ugly-button
    background blue

button.login
    @extend $ugly-red-button
```

**Becomes this CSS:**

``` css
button.login {
  border: 1px solid #000;
}
button.login {
  background: #f00;
}
```

If you want to merge this feature, I'll write some tests.
