### PR TITLE
Compress imported css files

### DIFF
--- a/lib/visitor/evaluator.js
+++ b/lib/visitor/evaluator.js
@@ -705,7 +705,7 @@ Evaluator.prototype.visitImport = function(imported){
   nodes.filename = found;
 
   var str = fs.readFileSync(found, 'utf8');
-  if (literal) return new nodes.Literal(str.replace(/\r\n?/g, "\n"));
+  if (literal && !this.options.compress) return new nodes.Literal(str.replace(/\r\n?/g, "\n"));
 
   // parse
   var block = new nodes.Block


### PR DESCRIPTION
Imported css files are not compressed even if the compression
property is set (issue #950). This patch fixes the issue by simply
parsing imported css files as stylus files when compression is on.
