### PR TITLE
Allows @extend to use mixins

### DIFF
--- a/lib/nodes/function.js
+++ b/lib/nodes/function.js
@@ -25,6 +25,7 @@ var Function = module.exports = function Function(name, params, body){
   this.name = name;
   this.params = params;
   this.block = body;
+  this.extends = [];
   if ('function' == typeof params) this.fn = params;
 };
 

--- a/lib/nodes/node.js
+++ b/lib/nodes/node.js
@@ -58,6 +58,20 @@ Node.prototype.__defineGetter__('nodeName', function(){
 });
 
 /**
+ * Gets the direct value or segment value
+ *
+ * @return {String}
+ * @api public
+ */
+
+Node.prototype.uniformVal = function(){
+  return this.val 
+        || (this.segments && this.segments.length 
+            && this.segments[0].val)
+        || '';
+};
+
+/**
  * Return this node.
  * 
  * @return {Node}

--- a/lib/visitor/compiler.js
+++ b/lib/visitor/compiler.js
@@ -343,6 +343,10 @@ Compiler.prototype.visitGroup = function(group){
   // selectors
   if (group.block.hasProperties) {
     var selectors = this.compileSelectors(stack);
+    if (!selectors.length){
+      stack.pop();
+      return;
+    }
     this.buf += (this.selector = selectors.join(this.compress ? ',' : ',\n'));
   }
 
@@ -461,7 +465,7 @@ Compiler.prototype.compileSelectors = function(arr){
     , buf = [];
 
   function interpolateParent(selector, buf) {
-    var str = selector.val.trim();
+    var str = selector.uniformVal().trim();
     if (buf.length) {
       for (var i = 0, len = buf.length; i < len; ++i) {
         if (~buf[i].indexOf('&')) {
@@ -478,7 +482,7 @@ Compiler.prototype.compileSelectors = function(arr){
     if (i) {
       arr[i].forEach(function(selector){
         if (selector.inherits) {
-          buf.unshift(selector.val);
+          buf.unshift(selector.uniformVal());
           compile(arr, i - 1);
           buf.shift();
         } else {
@@ -487,6 +491,7 @@ Compiler.prototype.compileSelectors = function(arr){
       });
     } else {
       arr[0].forEach(function(selector){
+        if (!selector.uniformVal()) return;
         var str = interpolateParent(selector, buf);
         selectors.push(self.indent + str.trimRight());
       });

--- a/lib/visitor/normalizer.js
+++ b/lib/visitor/normalizer.js
@@ -66,7 +66,6 @@ Normalizer.prototype.visitRoot = function(block){
     switch (node.nodeName) {
       case 'null':
       case 'expression':
-      case 'function':
       case 'jsliteral':
       case 'unit':
         continue;
@@ -198,6 +197,26 @@ Normalizer.prototype.visitMedia = function(media){
 }
 
 /**
+ * Visit Function.
+ */
+
+Normalizer.prototype.visitFunction = function(fn){
+  var block = new nodes.Block;
+
+  var group = new nodes.Group;
+  group.push(fn);
+
+  var block = new nodes.Block;
+  block.push(group);
+
+  this.map[fn.name] = [group];
+
+  this.visitGroup(group);
+
+  return block;
+}
+
+/**
  * Apply `group` extensions.
  *
  * @param {Group} group
@@ -256,13 +275,14 @@ Normalizer.prototype.compileSelectors = function(arr){
   function compile(arr, i) {
     if (i) {
       arr[i].forEach(function(selector){
-        buf.unshift(selector.val);
+        buf.unshift(selector.uniformVal());
         compile(arr, i - 1);
         buf.shift();
       });
     } else {
       arr[0].forEach(function(selector){
-        var str = selector.val.trim();
+        if (!selector.uniformVal()) return;
+        var str = selector.uniformVal().trim();
         if (buf.length) {
           for (var i = 0, len = buf.length; i < len; ++i) {
             if (~buf[i].indexOf('&')) {


### PR DESCRIPTION
This patch simply lets mixins be extended as if they were css blocks.

```
foo(){
   div.bar {
       background-color: red
   }
}

.myclass {
   @extend foo
}

.anotherclass {
   @extend foo
} 
```

Output will be:

```
.myclass div,
.anotherclass div {
  background-color: red;
}
```

If instead, you used the mixins normally, you wouldn't get the optimization of the combined selector. In the future, it'd be cool if we can do `@extend border-radius(4px)` and anywhere else that is used, will be combined using a comma selector. This is one step toward that direction.
