### PR TITLE
Capitalize git repo URL (it is case sensitive)

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   , "version": "0.32.1"
   , "author": "TJ Holowaychuk <tj@vision-media.ca>"
   , "keywords": ["css", "parser", "style", "stylesheets", "jade", "language"]
-  , "repository": "git://github.com/learnboost/stylus"
+  , "repository": "git://github.com/LearnBoost/stylus"
   , "main": "./index.js"
   , "browserify": "./lib/browserify.js"
   , "engines": { "node": "*" }


### PR DESCRIPTION
This PR corrects the capitalization of the git repo URL in package.json.

```
$ git clone git://github.com/learnboost/stylus
Cloning into 'stylus'...
fatal: remote error: 
  Repository not found.
$ git clone git://github.com/LearnBoost/stylus
Cloning into 'stylus'...
remote: Counting objects: 15956, done.
remote: Compressing objects: 100% (8640/8640), done.
remote: Total 15956 (delta 7641), reused 15269 (delta 6982)
Receiving objects: 100% (15956/15956), 4.63 MiB | 394 KiB/s, done.
Resolving deltas: 100% (7641/7641), done.
```
