### PR TITLE
TextMate "Compile and Display" command works on files with imports

### DIFF
--- a/editors/Stylus.tmbundle/Commands/Compile and Display CSS.tmCommand
+++ b/editors/Stylus.tmbundle/Commands/Compile and Display CSS.tmCommand
@@ -16,6 +16,7 @@ function highlight {
   fi
 }
 
+cd $TM_DIRECTORY
 ${TM_STYLUS:=stylus} | highlight</string>
 	<key>input</key>
 	<string>selection</string>


### PR DESCRIPTION
Without cd'ing to the current files' directory, Stylus imports would fail.
