### PR TITLE
Correction for non symmetrical src and dest paths in middleware.

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -15,6 +15,7 @@ var stylus = require('./stylus')
   , dirname = require('path').dirname
   , mkdirp = require('mkdirp')
   , join = require('path').join
+  , sep = require('path').sep
   , debug = require('debug')('stylus:middleware');
 
 /**
@@ -109,6 +110,11 @@ module.exports = function(options){
     if ('GET' != req.method && 'HEAD' != req.method) return next();
     var path = url.parse(req.url).pathname;
     if (/\.css$/.test(path)) {
+
+      // check for dest-path overlap
+      var overlap = compare(dest, path);
+      path = path.slice(overlap.length);
+
       var cssPath = join(dest, path)
         , stylusPath = join(src, path.replace('.css', '.styl'));
 
@@ -208,4 +214,24 @@ function checkImports(path, fn) {
       --pending || fn(changed);
     });
   });
+}
+
+/**
+ * get the overlaping path from the end of path A, and the begining of path B.
+ *
+ * @param {String} pathA
+ * @param {String} pathB
+ * @return {String}
+ * @api private
+ */
+
+function compare(pathA, pathB) {
+  pathA = pathA.split(sep);
+  pathB = pathB.split(sep);
+  var overlap = [];
+  while(pathA[pathA.length - 1] == pathB[0]) {
+    overlap.push(pathA.pop());
+    pathB.shift();
+  }
+  return overlap.join(sep);
 }


### PR DESCRIPTION
Corrects a flaw in path resolution for source files in stylus' middleware. See the following illustration:

Suppose we instance the middleware with the following dest and src paths.

```
dest: "./assets/css",
src: "./style"
```

Also assume the public directory is `./assets`. Now suppose a resource is requested; `/css/main.css`. The current implementation does not compare the dest path and the request path for overlap, instead it preforms a join. This produces incorrect src and dest file paths; a destination of `./assets/css/css/main.css`, and a source of `./style/css/main.css`.

This can be corrected by comparing the dest path to the request path; `./assets/css` and `/css/main.css`. By removing the overlapping `css` segment from the path, expected behaviour is obtained; a destination of `./assets/css/main.css`, and a source of `./style/main.css`
## 

Thanks for your hard work on Stylus,
Its much appreciated.
- Robert
