### PR TITLE
#358: Fixed non-code capitalization of “CSS” and “Stylus”

### DIFF
--- a/bin/stylus
+++ b/bin/stylus
@@ -91,7 +91,7 @@ var plugins = [];
 var urlFunction = false;
 
 /**
- * Include css on import.
+ * Include CSS on import.
  */
 
 var includeCSS = false;
@@ -121,21 +121,21 @@ var usage = [
   , '  Options:'
   , ''
   , '    -i, --interactive       Start interactive REPL'
-  , '    -u, --use <path>        Utilize the stylus plugin at <path>'
-  , '    -U, --inline            Utilize image inlining via data uri support'
+  , '    -u, --use <path>        Utilize the Stylus plugin at <path>'
+  , '    -U, --inline            Utilize image inlining via data URI support'
   , '    -w, --watch             Watch file(s) for changes and re-compile'
   , '    -o, --out <dir>         Output to <dir> when passing files'
-  , '    -C, --css <src> [dest]  Convert css input to stylus'
+  , '    -C, --css <src> [dest]  Convert CSS input to Stylus'
   , '    -I, --include <path>    Add <path> to lookup paths'
-  , '    -c, --compress          Compress css output'
+  , '    -c, --compress          Compress CSS output'
   , '    -d, --compare           Display input along with output'
-  , '    -f, --firebug           Emits debug infos in the generated css that'
+  , '    -f, --firebug           Emits debug infos in the generated CSS that'
   , '                            can be used by the FireStylus Firebug plugin'
-  , '    -l, --line-numbers      Emits comments in the generated css'
-  , '                            indicating the corresponding stylus line'
+  , '    -l, --line-numbers      Emits comments in the generated CSS'
+  , '                            indicating the corresponding Stylus line'
   , '    --import <file>         Import stylus <file>'
-  , '    --include-css           Include regular css on @import'
-  , '    -V, --version           Display the version of stylus'
+  , '    --include-css           Include regular CSS on @import'
+  , '    -V, --version           Display the version of Stylus'
   , '    -h, --help              Display help information'
   , ''
 ].join('\n');
@@ -320,7 +320,7 @@ var options = {
 
 var str = '';
 
-// Convert css to stylus
+// Convert CSS to Stylus
 
 if (convertCSS) {
     switch (files.length) {
@@ -350,7 +350,7 @@ if (convertCSS) {
 }
 
 /**
- * Start stylus REPL.
+ * Start Stylus REPL.
  */
 
 function repl() {
@@ -424,7 +424,7 @@ function repl() {
 }
 
 /**
- * Highlight the given string of stylus.
+ * Highlight the given string of Stylus.
  */
 
 function highlight(str) {
@@ -535,7 +535,7 @@ function compileFile(file) {
 }
 
 /**
- * Write the given css output.
+ * Write the given CSS output.
  */
 
 function writeFile(file, css) {

--- a/docs/bifs.md
+++ b/docs/bifs.md
@@ -291,7 +291,7 @@ Return `RGBA` from the r,g,b,a channels or provide a `color` to tweak the alpha.
       rgba(#ffcc00, 0.5)
       // rgba(255,204,0,0.5)
 
- Alternatively stylus supports the `#rgba` and `#rrggbbaa` notations as well:
+ Alternatively, Stylus supports the `#rgba` and `#rrggbbaa` notations as well:
  
     #fc08
     // => rgba(255,204,0,0.5)
@@ -323,9 +323,8 @@ below.
 
 ### darken(color, amount)
 
-Darken the given `color` by `amount`.This function is
-unit-sensitive, for example supporting percentages as shown
-below.
+Darken the given `color` by `amount`. This function is
+unit-sensitive. For example, note the percentages below.
 
     darken(#D62828, 30)
     // => #551010
@@ -349,7 +348,7 @@ Saturate the given `color` by `amount`.
 
 ### invert(color)
 
-Inverts the color. The red, green, and blue values are inverted, while the opacity is left alone.
+Inverts the color. The red, green, and blue values are inverted, while opacity is left alone.
 
     invert(#d62828)
     // => #29d7d7

--- a/examples/comments.styl
+++ b/examples/comments.styl
@@ -8,7 +8,7 @@ body
 
 /*
 We can also use multi-line comments
-like this, which are native to css
+like this, which are native to CSS
 */
 
 form

--- a/lib/convert/css.js
+++ b/lib/convert/css.js
@@ -1,11 +1,11 @@
 /*!
- * Stylus - css to stylus conversion
+ * Stylus - CSS to Stylus conversion
  * Copyright(c) 2010 LearnBoost <dev@learnboost.com>
  * MIT Licensed
  */
 
 /**
- * Convert the given `css` to stylus source.
+ * Convert the given `css` to Stylus source.
  *
  * @param {String} css
  * @return {String}
@@ -32,7 +32,7 @@ function Converter(css) {
 }
 
 /**
- * Convert to stylus.
+ * Convert to Stylus.
  *
  * @return {String}
  * @api private

--- a/lib/functions/index.styl
+++ b/lib/functions/index.styl
@@ -224,7 +224,7 @@ join(delim, vals...)
   for val, i in vals
     buf += i ? delim + val : val
 
-// add a css rule to the containing block
+// add a CSS rule to the containing block
 
 // - This definition allows add-property to be used as a mixin
 // - It has the same effect as interpolation but allows users

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -35,10 +35,10 @@ var imports = {};
  *    `compile`   Custom compile function, accepting the arguments
  *                `(str, path)`.
  *    `compress`  Whether the output .css files should be compressed
- *    `firebug`   Emits debug infos in the generated css that can
+ *    `firebug`   Emits debug infos in the generated CSS that can
  *                be used by the FireStylus Firebug plugin
- *    `linenos`   Emits comments in the generated css indicating 
- *                the corresponding stylus line
+ *    `linenos`   Emits comments in the generated CSS indicating 
+ *                the corresponding Stylus line
  *
  * Examples:
  * 

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -299,9 +299,9 @@ Parser.prototype = {
         // unclosed, must be a block
         if (!this.lineContains('}')) return;
         // check if ':' is within the braces.
-        // though not required by stylus, chances
+        // though not required by Stylus, chances
         // are if someone is using {} they will
-        // use css-style props, helping us with
+        // use CSS-style props, helping us with
         // the ambiguity in this case
         var i = 0
           , la;

--- a/lib/visitor/compiler.js
+++ b/lib/visitor/compiler.js
@@ -19,7 +19,7 @@ var Visitor = require('./')
  *
  * Options:
  *
- *   - `compress`  Compress the css output, defaults to false
+ *   - `compress`  Compress the CSS output (default: false)
  *
  * @param {Node} root
  * @api public

--- a/lib/visitor/evaluator.js
+++ b/lib/visitor/evaluator.js
@@ -336,7 +336,7 @@ Evaluator.prototype.visitCall = function(call){
     fn = this.lookupFunction(call.name);
   }
 
-  // Undefined function, render literal css
+  // Undefined function? render literal CSS
   if (!fn || fn.nodeName != 'function') {
     debug('%s is undefined', call);
     var ret = this.literalCall(call);


### PR DESCRIPTION
A few minor tweaks to documentation strings along the way, too.
