### PR TITLE
Updated for handling asymmetric src and dest paths

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -15,6 +15,7 @@ var stylus = require('./stylus')
   , dirname = require('path').dirname
   , mkdirp = require('mkdirp')
   , join = require('path').join
+  , sep = require('path').sep
   , debug = require('debug')('stylus:middleware');
 
 /**
@@ -109,6 +110,12 @@ module.exports = function(options){
     if ('GET' != req.method && 'HEAD' != req.method) return next();
     var path = url.parse(req.url).pathname;
     if (/\.css$/.test(path)) {
+      
+      // check for dest-path overlap
+      var overlap = compare(dest, path);
+      // slice overlap and leading / from path
+      path = path.slice(overlap.length+1);
+      
       var cssPath = join(dest, path)
         , stylusPath = join(src, path.replace('.css', '.styl'));
 
@@ -208,4 +215,25 @@ function checkImports(path, fn) {
       --pending || fn(changed);
     });
   });
+}
+
+/**
+ * get the overlaping path from the end of path A, and the begining of path B.
+ * while ignoring leading / at start of path B
+ * 
+ * @param {String} pathA
+ * @param {String} pathB
+ * @return {String}
+ * @api private
+ */
+
+function compare(pathA, pathB) {
+  pathA = pathA.split(sep);
+  pathB = pathB.split(sep);
+  var overlap = [];
+  while(pathA[pathA.length - 1] == pathB[1]) {
+    overlap.push(pathA.pop());
+    pathB.shift();
+  }
+  return overlap.join(sep);
 }


### PR DESCRIPTION
The following src and dest format will also work now:

var app = connect();

app.middleware({
   src: __dirname + '/styles'
 , dest: __dirname + '/public/css'
 , compile: compile
})

app.use(connect.static(__dirname + '/public'));
