### PR TITLE
Removes 0.4 from .travis.yml.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - 0.4
   - 0.6
   - 0.8
   - 0.10


### PR DESCRIPTION
From Travis log:

```
$ nvm use 0.4
N/A version is not installed
```
