### PR TITLE
Removes duplicate calls from `this.calling`

### DIFF
--- a/lib/visitor/evaluator.js
+++ b/lib/visitor/evaluator.js
@@ -524,10 +524,8 @@ Evaluator.prototype.visitProperty = function(prop){
 
   // Function of the same name
   if (call && !literal && !prop.literal) {
-    this.calling.push(name);
     var args = nodes.Arguments.fromExpression(utils.unwrap(prop.expr));
     var ret = this.visit(new nodes.Call(name, args));
-    this.calling.pop();
     return ret;
   // Regular property
   } else {


### PR DESCRIPTION
This code is useless because it is duplicated in `visitCall` (https://github.com/LearnBoost/stylus/blob/master/lib/visitor/evaluator.js#L348 and https://github.com/LearnBoost/stylus/blob/master/lib/visitor/evaluator.js#L384).

For example:

```
border-radius(x)
  -moz-border-radius: x
  border-radius: x

.a
  border-radius: 5px

.b
  border-radius: 10px
```

`this.calling` before patch:

```
[]
[ 'border-radius', 'border-radius' ]
[ 'border-radius', 'border-radius' ]
[]
[]
[ 'border-radius', 'border-radius' ]
[ 'border-radius', 'border-radius' ]
[]
```

`this.calling` after patch:

```
[]
[ 'border-radius' ]
[ 'border-radius' ]
[]
[]
[ 'border-radius' ]
[ 'border-radius' ]
[]
```
