### PR TITLE
Fixes #1144. jsbin infinite loop

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -284,7 +284,7 @@ Parser.prototype = {
       , la;
 
     while (la = this.lookahead(i++)) {
-      if (~['indent', 'outdent', 'newline'].indexOf(la.type)) return;
+      if (~['indent', 'outdent', 'newline', 'eos'].indexOf(la.type)) return;
       if (type == la.type) return true;
     }
   },


### PR DESCRIPTION
Test example:

```
blink {
```

(without a newline)
