### PR TITLE
Allow multiple `end` event handlers + optional result css modification

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -87,17 +87,13 @@ Renderer.prototype.render = function(fn){
     var compiler = new Compiler(ast, this.options)
       , css = compiler.compile();
 
-    if (!fn) {
-      this.emit('end', css);
-      return css;
-    } else {
-      if (!this.listeners('end').length) {
-        return fn(null, css);
-      }
-      this.emit('end', css, function(err, css) {
-        fn(err, css);
-      });
+    var listeners = this.listeners('end');
+    if (fn) listeners.push(fn);
+    for (var i = 0, len = listeners.length; i < len; i++) {
+      var ret = listeners[i](null, css);
+      if (ret) css = ret;
     }
+    if (!fn) return css;
   } catch (err) {
     var options = {};
     options.input = err.input || this.str;


### PR DESCRIPTION
For example:

`autoprefixer.js`

``` javascript
var autoprefixer = require('autoprefixer');

var plugin = function() {
    return function(style) {
        this.on('end', function(err, css) {
            return autoprefixer.compile(css);
        });
    };
};
module.exports = plugin;
```

`csso.js`

``` javascript
var csso = require('csso');

var plugin = function() {
    return function(style) {
        this.on('end', function(err, css) {
            return csso.justDoIt(css);
        });
    };
};
module.exports = plugin;
```

`style.styl`

``` css
use('autoprefixer.js')
use('csso.js')

body
  box-shadow: 3px 3px 5px #ccc
  transform: scale(2)
```

`style.css` (result)

``` css
body{-webkit-box-shadow:3px 3px 5px #ccc;box-shadow:3px 3px 5px #ccc;-webkit-transform:scale(2);-ms-transform:scale(2);transform:scale(2)}
```
