### PR TITLE
Avoid compressing time units.

### DIFF
--- a/lib/visitor/compiler.js
+++ b/lib/visitor/compiler.js
@@ -319,9 +319,8 @@ Compiler.prototype.visitUnit = function(unit){
 
   // Compress
   if (this.compress) {
-    // Zero is always '0', unless when
-    // a percentage, this is required by keyframes
-    if ('%' != type && 0 == n) return '0';
+    // Always return '0' unless the unit is a percentage or time
+    if ('%' != type && 's' != type && 'ms' != type && 0 == n) return '0';
     // Omit leading '0' on floats
     if (float && n < 1 && n > -1) {
       return n.toString().replace('0.', '.') + type;

--- a/test/cases/compress.units.css
+++ b/test/cases/compress.units.css
@@ -1,2 +1,3 @@
 body{foo:0;foo:0;foo:15;foo:-15;foo:15px;foo:-15px}
 body{foo:.1;foo:-.1;foo:1.1;foo:-1.1;foo:.1;foo:-.1;foo:10.1;foo:-10.1}
+body{foo:0s;foo:0ms}

--- a/test/cases/compress.units.styl
+++ b/test/cases/compress.units.styl
@@ -15,4 +15,7 @@ body
   foo -0.1
   foo 10.1
   foo -10.1
-  
+
+body
+  foo 0s
+  foo 0ms


### PR DESCRIPTION
This patch fixes an issue where Stylus compresses zero-duration time units.

E.g:

``` sass
body
  animation: spin 1s linear 0s infinite
```

Becomes:

``` css
body {animation: spin 1s linear 0 infinite}
```

According to the [CSS time unit specification](https://developer.mozilla.org/en-US/docs/Web/CSS/time) speficying time without a unit is invalid.
