### PR TITLE
Correct name of MDN in --help documentation

### DIFF
--- a/bin/stylus
+++ b/bin/stylus
@@ -124,7 +124,7 @@ var usage = [
   , ''
   , '  Commands:'
   , ''
-  , '    help [<type>:]<prop> Opens help info at MDC for <prop> in'
+  , '    help [<type>:]<prop> Opens help info at MDN for <prop> in'
   , '                         your default browser. Optionally'
   , '                         searches other resources of <type>:'
   , '                         safari opera w3c ms caniuse quirksmode'


### PR DESCRIPTION
The site was formerly called the Mozilla Developer Center (MDC) but now
goes by Mozilla Developer Network (MDN).
