### PR TITLE
Improved readability in docs describing block mixins

### DIFF
--- a/docs/mixins.html
+++ b/docs/mixins.html
@@ -127,13 +127,13 @@ form input[type=button]
 <p>The passed block would be available inside the mixin as <code>block</code> variable, that then could be used with interpolation:</p>
 
 <pre><code>foo()
-  .foo
+  .bar
     {block}
 
 +foo
   width: 10px
 
-=&gt; .foo {
+=&gt; .bar {
      width: 10px;
    }
 </code></pre>

--- a/docs/mixins.md
+++ b/docs/mixins.md
@@ -112,13 +112,13 @@ You can pass blocks to mixins by calling mixin with `+` prefix:
 The passed block would be available inside the mixin as `block` variable, that then could be used with interpolation:
 
     foo()
-      .foo
+      .bar
         {block}
 
     +foo
       width: 10px
 
-    => .foo {
+    => .bar {
          width: 10px;
        }
 


### PR DESCRIPTION
Because two consecutive `foo` are confusing.
