### PR TITLE
Preserve hashes in url() function

### DIFF
--- a/lib/functions/url.js
+++ b/lib/functions/url.js
@@ -71,6 +71,7 @@ module.exports = function(options) {
     url = parse(url);
     var ext = extname(url.pathname)
       , mime = mimes[ext]
+      , hash = url.hash || ''
       , literal = new nodes.Literal('url("' + url.href + '")')
       , paths = _paths.concat(this.paths)
       , buf;
@@ -101,7 +102,7 @@ module.exports = function(options) {
     if (false !== sizeLimit && buf.length > sizeLimit) return literal;
 
     // Encode
-    return new nodes.Literal('url("data:' + mime + ';base64,' + buf.toString('base64') + '")');
+    return new nodes.Literal('url("data:' + mime + ';base64,' + buf.toString('base64') + hash + '")');
   };
 
   fn.raw = true;

--- a/test/cases/functions.url.css
+++ b/test/cases/functions.url.css
@@ -1,0 +1,16 @@
+.embed-no-hash {
+  color: #c00;
+  background: url("data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPHN2ZyB3aWR0aD0iMTIwIiBoZWlnaHQ9IjEyMCIgdmlld1BvcnQ9IjAgMCAxMjAgMTIwIiB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CiAgICA8Y2lyY2xlIGN4PSI2MCIgY3k9IjYwIiByPSI1MCIvPgo8L3N2Zz4K");
+}
+.embed-with-hash {
+  color: #c00;
+  background: url("data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPHN2ZyB3aWR0aD0iMTIwIiBoZWlnaHQ9IjEyMCIgdmlld1BvcnQ9IjAgMCAxMjAgMTIwIiB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CiAgICA8Y2lyY2xlIGN4PSI2MCIgY3k9IjYwIiByPSI1MCIvPgo8L3N2Zz4K#some-id");
+}
+.too-big-no-hash {
+  color: #c00;
+  background: url("tiger.svg");
+}
+.too-big-with-hash {
+  color: #c00;
+  background: url("tiger.svg#some-id");
+}

--- a/test/cases/functions.url.styl
+++ b/test/cases/functions.url.styl
@@ -1,0 +1,19 @@
+.embed-no-hash {
+  color: #c00;
+  background: url("circle.svg");
+}
+
+.embed-with-hash {
+  color: #c00;
+  background: url("circle.svg#some-id");
+}
+
+.too-big-no-hash {
+  color: #c00;
+  background: url("tiger.svg");
+}
+
+.too-big-with-hash {
+  color: #c00;
+  background: url("tiger.svg#some-id");
+}

--- a/test/images/circle.svg
+++ b/test/images/circle.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg width="120" height="120" viewPort="0 0 120 120" version="1.1" xmlns="http://www.w3.org/2000/svg">
+    <circle cx="60" cy="60" r="50"/>
+</svg>


### PR DESCRIPTION
`url()` function should preserve hashes after base64 conversion.

For example

``` css
div {
  background: url("circle.svg#some-id");
}
```

should compiles to

``` css
div {
  background: url("data:image/svg+xml;base64,PD94b <…> z4K#some-id");
}
```

but now it compiles to

``` css
div {
  background: url("data:image/svg+xml;base64,PD94b <…> z4K");
}
```
