### PR TITLE
Adding root reference

### DIFF
--- a/History.md
+++ b/History.md
@@ -3,6 +3,7 @@
 
   * Added `require()` bif, #1287.
   * Added file globbing, #1306 and #1013.
+  * Added root reference, part of #1240.
   * Added basic support for `@block` entity, #1290.
   * Added string support for `selector()` bif, #1279.
   * Added options as an optional argument for `use()` bif, #1297.

--- a/lib/functions/index.js
+++ b/lib/functions/index.js
@@ -1096,7 +1096,7 @@ exports.selector = function selector(sel){
   var stack = this.selectorStack
     , group;
   if (sel && 'string' == sel.nodeName) {
-    if (!~sel.val.indexOf('&')) return sel.val;
+    if (!~sel.val.indexOf('&') && '/' !== sel.val.charAt(0)) return sel.val;
     group = new nodes.Group;
     sel = new nodes.Selector([sel.val]);
     sel.val = sel.segments.join('');

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -55,6 +55,7 @@ var selectorTokens = [
   , '{'
   , '}'
   , '.'
+  , '/'
 ];
 
 /**
@@ -647,6 +648,7 @@ Parser.prototype = {
             case '&':
             case '[':
             case '.':
+            case '/':
               return this.selector();
             case '+':
               return 'function' == this.lookahead(2).type

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -25,7 +25,7 @@ var nodes = require('./nodes')
 
 exports.absolute = function(path){
   // On Windows the path could start with a drive letter, i.e. a:\\ or two leading backslashes
-  return path.substr(0, 2) == '\\\\' || path[0] == '/' || /^[a-z]:\\/i.test(path);
+  return path.substr(0, 2) == '\\\\' || '/' === path.charAt(0) || /^[a-z]:\\/i.test(path);
 };
 
 /**
@@ -363,20 +363,20 @@ exports.compileSelectors = function(arr, leaveHidden){
   var self = this
     , selectors = []
     , buf = []
-    , hiddenSelectorRegexp = /^\s*\$/;
+    , hiddenSelectorRegexp = /^\s*\/?\$/;
 
   function interpolateParent(selector, buf) {
-    var str = selector.val.trim();
+    var str = selector.val.replace(/^\//g, '').trim();
     if (buf.length) {
       for (var i = 0, len = buf.length; i < len; ++i) {
-        if (~buf[i].indexOf('&')) {
-          str = buf[i].replace(/&/g, str).trim();
+        if (~buf[i].indexOf('&') || '/' === buf[i].charAt(0)) {
+          str = buf[i].replace(/&/g, str).replace(/^\//g, '').trim();
         } else {
           str += ' ' + buf[i].trim();
         }
       }
     }
-    return str;
+    return str.trim();
   }
 
   function compile(arr, i) {
@@ -404,5 +404,8 @@ exports.compileSelectors = function(arr, leaveHidden){
 
   compile(arr, arr.length - 1);
 
-  return selectors;
+  // Return the list with unique selectors only
+  return selectors.filter(function(value, index, self){
+    return self.indexOf(value) === index;
+  });
 };

--- a/test/cases/selector.reference.css
+++ b/test/cases/selector.reference.css
@@ -1,0 +1,37 @@
+.foo {
+  width: 10px;
+}
+.bar,
+.foo {
+  width: 20px;
+}
+.bar {
+  width: 30px;
+}
+.bar {
+  width: 50px;
+}
+.foo {
+  width: 60px;
+}
+.foo .bar,
+.baz {
+  width: 70px;
+  content: '.foo .bar,.baz';
+}
+.foo {
+  width: 80px;
+}
+.zzz {
+  width: 90px;
+}
+.foo,
+.bar {
+  width: 100px;
+}
+.baz {
+  width: 110px;
+}
+.raz {
+  width: 120px;
+}

--- a/test/cases/selector.reference.styl
+++ b/test/cases/selector.reference.styl
@@ -1,0 +1,47 @@
+/.foo
+  width: 10px
+
+/.bar,
+.foo
+  width: 20px
+
+.foo
+  /.bar
+    width: 30px
+
+/
+  width: 40px
+  /.bar
+    width: 50px
+
+.foo
+  width: 60px
+
+  .bar,
+  /.baz
+    width: 70px
+
+    content: selector()
+
+zzzs()
+  /$fshhh
+    width: 90px
+
+.foo
+  width: 80px
+
+  zzzs()
+
+.zzz
+  @extends $fshhh
+
+.foo,
+.bar
+  width: 100px
+
+  /.baz
+    width: 110px
+
+  /
+    .raz
+      width: 120px


### PR DESCRIPTION
Subj: root reference — `/` — added. See its description at #1240.

Also, as a side effect, we now remove duplicates from the selector lists.
