### PR TITLE
For #1313, adds import-index-into-index test

### DIFF
--- a/test/cases/import.index.self/a.styl
+++ b/test/cases/import.index.self/a.styl
@@ -1,0 +1,2 @@
+
+@import 'index'

--- a/test/cases/import.index.self/index.styl
+++ b/test/cases/import.index.self/index.styl
@@ -1,0 +1,3 @@
+
+@import 'index'
+@import 'a'


### PR DESCRIPTION
This is for https://github.com/LearnBoost/stylus/issues/1313. I get `Failed to locate @import file index.styl` when I try for `index.styl` but `Maximum call stack size exceeded` when I try for `a.styl`. When I actually run the tests on OS X, they pass, though. Unfortunately I couldn’t get the tests to run on Windows.
