### PR TITLE
Fixed typo when using a block mixin

### DIFF
--- a/docs/mixins.md
+++ b/docs/mixins.md
@@ -1,4 +1,3 @@
-
 ## Mixins
 
 Both mixins and functions are defined in the same manner, but they are applied in different ways. 
@@ -115,7 +114,7 @@ The passed block would be available inside the mixin as `block` variable, that t
       .bar
         {block}
 
-    +foo
+    +foo()
       width: 10px
 
     => .bar {


### PR DESCRIPTION
So I had a go at using block mixins and doing this didn't work:

```
large()
  @media only screen and (min-width: 992px)
    {block}

+large
  padding: 0
```

It just compiled to `large{padding:0}`, so I did this and it worked:

```
large()
  @media only screen and (min-width: 992px)
    {block}

+large()
  padding: 0
```

Hence I thought I'd update the docs typo :)
