### PR TITLE
Fix type() BIF to return 'list' for expression lists

### DIFF
--- a/lib/functions/index.js
+++ b/lib/functions/index.js
@@ -155,8 +155,14 @@ exports.hsl = function hsl(hue, saturation, lightness){
 exports.typeof =
 exports['type-of'] = function type(node){
   utils.assertPresent(node, 'expression');
-  var expression = node.toExpression();
-  return expression.nodes.length > 1 ? 'list' : expression.first.nodeName;
+
+  var isList = function isList(expression) {
+    var nodes = expression.nodes;
+    if (! nodes) return false;
+    return nodes.length > 1 || isList(nodes[0]);
+  };
+
+  return isList(node) ? 'list' : node.first.nodeName;
 }).raw = true;
 
 /**

--- a/test/cases/bifs.type.css
+++ b/test/cases/bifs.type.css
@@ -10,4 +10,5 @@ body {
   background: 'ident';
   background: 'object';
   background: 'list';
+  background: 'list';
 }

--- a/test/cases/bifs.type.styl
+++ b/test/cases/bifs.type.styl
@@ -1,3 +1,7 @@
+hash = {foo: 1, bar: 2, baz: 3}
+
+hash-list = {foo: 1} {bar: 2} {baz: 3}
+
 body
   border-type = solid
   size = 15px
@@ -10,5 +14,6 @@ body
   background type(size)
   background type(type)
   background type(border-type)
-  background type({ a: 1, b: 2, c: 3 })
-  background type(1 2 3)
+  background type(hash)
+  background type(hash-list)
+  background type(((((1 2 3)))))


### PR DESCRIPTION
This fixes some of the behavior described in #1333. The type BIF currently is not a raw function, so it will return the type of the first node in a list:

```
list = 1 foo "bar"

type(list) // => "unit"
```

This makes it difficult to check if a value is an object or a list of objects:

```
hash = {foo: 1, bar: 2, baz: 3}
hash-list = {foo: 1} {bar: 2} {baz: 3}

type(hash) // => "object"
type(hash-list) // => "object"
```

This commit makes the operator behave as expected:

```
type(list) // => "list"
type(hash-list) // => "list"
```
