### PR TITLE
win32 debug info, incorrect file path

### DIFF
--- a/lib/visitor/compiler.js
+++ b/lib/visitor/compiler.js
@@ -452,7 +452,9 @@ Compiler.prototype.debugInfo = function(node){
 
   if (this.firebug){
     // debug info for firebug, the crazy formatting is needed
-    path = 'file\\\:\\\/\\\/' + path.replace(/(\/|\.)/g, '\\$1');
+    path = 'file\\\:\\\/\\\/' + path.replace(/([.:/\\])/g, function(m) {
+      return '\\' + (m === '\\' ? '\/' : m)
+    });
     line = '\\00003' + line;
     this.buf += '\n@media -stylus-debug-info'
       + '{filename{font-family:' + path


### PR DESCRIPTION
when set firebug true, then win32 platform will print incorrect file path

```
@media -stylus-debug-info{filename{font-family:file\:\/\/D:\stylus\public\.styl}line{font-family:\000035}}
```

fix it, the corrent debug info is:

```
@media -stylus-debug-info{filename{font-family:file\:\/\/D\:\/stylus\/public\.styl}line{font-family:\000035}}
```

then, the [SASS-Inspector](https://github.com/tinganho/SASS-Inspector) can work!
