### PR TITLE
Decimal part of units can be lost when coercing from a string

### DIFF
--- a/lib/nodes/unit.js
+++ b/lib/nodes/unit.js
@@ -169,7 +169,7 @@ Unit.prototype.coerce = function(other){
       return new nodes.Unit(b.val, a.type);
     }
   } else if ('string' == other.nodeName) {
-    var val = parseInt(other.val, 10);
+    var val = parseFloat(other.val);
     if (isNaN(val)) Node.prototype.coerce.call(this, other);
     return new nodes.Unit(val);
   } else {

--- a/test/cases/operators.css
+++ b/test/cases/operators.css
@@ -38,3 +38,15 @@ body {
   foo: X::Micrsoft::crap(#0f0);
   foo: <foo, bar, baz>;
 }
+body {
+  foo: true;
+  foo: true;
+  foo: true;
+  foo: true;
+  foo: true;
+  foo: true;
+  foo: true;
+  foo: true;
+  foo: true;
+  foo: true;
+}

--- a/test/cases/operators.equality.css
+++ b/test/cases/operators.equality.css
@@ -7,6 +7,9 @@ body {
   foo: true;
   foo: true;
   foo: true;
+  foo: true;
+  foo: true;
+  foo: true;
 }
 body {
   foo: true;

--- a/test/cases/operators.equality.styl
+++ b/test/cases/operators.equality.styl
@@ -7,6 +7,9 @@ body
   foo 5 != 1
   foo 5 != asdf
   foo 5 == asdf == false
+  foo !(5 == '5.1')
+  foo 5 != '5.1'
+  foo '5' != '5.1'
 
 body
   foo 1000ms == 1s

--- a/test/cases/operators.styl
+++ b/test/cases/operators.styl
@@ -93,4 +93,16 @@ body
   foo: '<a: %s b: %s>' % 1 2 // not what you might think
   foo: '<a: %s b: %s>' % (1 2)
   foo: 'X::Micrsoft::crap(%s)' % rgb(0,255,0)
-  foo: '<%s, %s, %s>' % (foo bar baz)  
+  foo: '<%s, %s, %s>' % (foo bar baz)
+
+body
+  foo 5 < '5.1'
+  foo 5 < 5.1
+  foo 5 <= 5.1
+  foo !(5 < '5')
+  foo 5.1 > 5
+  foo !(5 > 5)
+  foo '5.1' > 5
+  foo '5.1' > '5'
+  foo (5 - "5.1") != 0
+  foo !(5 == '5.1')


### PR DESCRIPTION
In `nodes.Unit`, `parseInt()` [is used](https://github.com/LearnBoost/stylus/blob/d0cbf5ea8651bd4f61b598d6ddca598099f27c85/lib/nodes/unit.js#L172)  for coercing from a string node, discarding the decimal part. 

This can lead to untrue results in operations with mixed operands:

``` stylus
body
  foo (5 - "5.1") != 0
  foo !(5 == '5.1')
  foo 5 != '5.1'
  foo 5 < '5.1'
```

Expected:

``` css
body {
  foo: true;
  foo: true;
  foo: true;
  foo: true;
}
```

Actual result:

``` css
body {
  foo: false;
  foo: false;
  foo: false;
  foo: false;
}
```
