### PR TITLE
Added 'use' option to Stylus middelware Options.

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -42,6 +42,7 @@ var imports = {};
  *                be used by the FireStylus Firebug plugin
  *    `linenos`   Emits comments in the generated CSS indicating 
  *                the corresponding Stylus line
+ *    `use`       Expose Renderer .use(fn) on default compile callback.
  *
  * Examples:
  * 
@@ -96,13 +97,17 @@ module.exports = function(options){
   // Default dest dir to source
   var dest = options.dest || src;
 
+  // Default .use(fn) function - no-op.
+  options.use = options.use || function() {};
+
   // Default compile callback
   options.compile = options.compile || function(str, path){
     return stylus(str)
       .set('filename', path)
       .set('compress', options.compress)
       .set('firebug', options.firebug)
-      .set('linenos', options.linenos);
+      .set('linenos', options.linenos)
+      .use(options.use);
   };
 
   // Middleware


### PR DESCRIPTION
Adds a `{ use : fn }` to 

``` javascript
Stylus.midddleware({options})
```

to expose Stylus  `.use(fn)` capability.

E.g.:

``` javascript
var autoprefixer = require('autoprefixer-stylus')();
...
app.use(stylus.middleware({
  src: __dirname + '/public'
 ,compress: false
 ,use : autoprefixer
}));
```
