### PR TITLE
Move test runner out of make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,19 +15,15 @@ cd /tmp && \
 endef
 
 TM_BUNDLE_DEST = $(shell $(DETERMINE_TEXTMATE_BUNDLE_PATH))
-REPORTER = dot
 
 test:
-	@./node_modules/.bin/mocha test/ test/middleware/ \
-		--require should \
-		--bail \
-		--reporter $(REPORTER)
+	npm test
 
 test-cov: lib-cov
-	STYLUS_COV=1 $(MAKE) REPORTER=html-cov > coverage.html
+	STYLUS_COV=1 npm run-script test-cov
 
 lib-cov: lib
-	jscoverage $< $@
+	./node_modules/.bin/jscoverage $< $@
 
 install-bundle:
 	mkdir -p "$(TM_BUNDLE_DEST)"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   },
   "scripts": {
     "prepublish": "npm prune",
-    "test": "make test"
+    "test": "mocha test/ test/middleware/ --require should --bail --reporter dot",
+    "test-cov": "mocha test/ test/middleware/ --require should --bail --reporter html-cov > coverage.html"
   },
   "dependencies": {
     "css-parse": "1.7.x",


### PR DESCRIPTION
- Make does not come on windows (by default)
- We were doing nothing special with the make file for the tests
- Putting the mocha command inside of npm test is SUPER portable
- Attaching tools like node-debug while running the tests is now as simple as `node-debug npm test`

---

TLDR: make is not the best tool for node projects.
