### PR TITLE
Added option --extension / -e which sets filename extension

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,5 @@
+  * Added option to use custom filename extension.
+
 0.46.3 / 2014-06-09
 ===================
 

--- a/bin/stylus
+++ b/bin/stylus
@@ -53,6 +53,12 @@ var prefix = '';
 var print = false;
 
 /**
+ * CSS filename extension;
+ */
+
+var extension = '.css';
+
+/**
  * Firebug flag
  */
 
@@ -157,6 +163,7 @@ var usage = [
   , '    -I, --include <path>    Add <path> to lookup paths'
   , '    -c, --compress          Compress CSS output'
   , '    -d, --compare           Display input along with output'
+  , '    -e, --extension <ext>   Use <ext> as the output file extension'
   , '    -f, --firebug           Emits debug infos in the generated CSS that'
   , '                            can be used by the FireStylus Firebug plugin'
   , '    -l, --line-numbers      Emits comments in the generated CSS'
@@ -196,6 +203,11 @@ while (args.length) {
     case '-C':
     case '--css':
       convertCSS = true;
+      break;
+    case '-e':
+    case '--extension':
+      extension = args.shift();
+      if (!extension) throw new Error('--extension <ext> required');
       break;
     case '-f':
     case '--firebug':
@@ -634,8 +646,8 @@ function writeFile(file, css) {
   if (print) return process.stdout.write(css);
   // --out support
   var path = dest
-    ? join(dest, basename(file, '.styl') + '.css')
-    : file.replace(/\.styl$/i, '.css');
+    ? join(dest, basename(file, '.styl') + extension)
+    : file.replace(/\.styl$/i, extension);
   fs.writeFile(path, css, function(err){
     if (err) throw err;
     console.log('  \033[90mcompiled\033[0m %s', path);

--- a/docs/executable.md
+++ b/docs/executable.md
@@ -28,6 +28,7 @@ Stylus ships with the `stylus` executable for converting Stylus to CSS.
         -I, --include <path>    Add <path> to lookup paths
         -c, --compress          Compress CSS output
         -d, --compare           Display input along with output
+        -e, --extension <ext>   Use <ext> as the output file extension
         -f, --firebug           Emits debug infos in the generated CSS that
                                 can be used by the FireStylus Firebug plugin
         -l, --line-numbers      Emits comments in the generated CSS
@@ -78,6 +79,10 @@ Try Stylus some in the terminal!  Type below and press `CTRL-D` for `__EOF__`:
   the [FireStylus extension for Firebug](//github.com/LearnBoost/stylus/blob/master/docs/firebug.md):
 
       $ stylus --firebug <path>
+
+  The default extension is `.css`. Use the `extension` option to use a custom extension:
+
+      $ stylus one.styl --extension .min.css
 
 ## Prefixing classes
 


### PR DESCRIPTION
The default is `.css`, but for example in production we might want to use an extension such as `.min.css` to distinguish minified files from the source files (and serve up only production files).
