### PR TITLE
Allow idents and units coercion (consistent with strings)

### DIFF
--- a/lib/nodes/ident.js
+++ b/lib/nodes/ident.js
@@ -119,6 +119,8 @@ Ident.prototype.coerce = function(other){
     case 'string':
     case 'literal':
       return new Ident(other.string);
+    case 'unit':
+      return new Ident(other.toString());
     default:
       return Node.prototype.coerce.call(this, other);
   }

--- a/test/cases/coercion.css
+++ b/test/cases/coercion.css
@@ -11,5 +11,7 @@ body {
   foo: 2in;
   foo: 50cm;
   foo: 12.834645669291339pt;
+  foo: bar10px;
+  foo: bar10em;
+  foo: bar10;
 }
-

--- a/test/cases/coercion.styl
+++ b/test/cases/coercion.styl
@@ -11,3 +11,6 @@ body
   foo 1in + 2.54cm
   foo (100cm / 2cm)
   foo 10pt + 1mm
+  foo bar + 10px
+  foo bar + 10em
+  foo bar + 10


### PR DESCRIPTION
Currently:

``` scss
foo + 10px // error!
'foo' + 10px // 'foo10px'
```

After patch:

``` scss
foo + 10px // foo10px
'foo' + 10px // 'foo10px'
```
