### PR TITLE
Allow globals and functions to be set in options

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -35,8 +35,8 @@ module.exports = Renderer;
 
 function Renderer(str, options) {
   options = options || {};
-  options.globals = {};
-  options.functions = {};
+  options.globals = options.globals || {};
+  options.functions = options.functions || {};
   options.imports = [join(__dirname, 'functions')];
   options.paths = options.paths || [];
   options.filename = options.filename || 'stylus';


### PR DESCRIPTION
Not sure why these options are ignored right now...? But [my stylus broccoli filter](https://github.com/gabrielgrant/broccoli-stylus-single) relies on the options hash as the only way to control rendering, so these options would be quite helpful (I just had someone on IRC quick-patch his local copy of stylus with this fix, but I'd certainly rather avoid that in the future)
