### PR TITLE
Fix for #955: Stop weird behavior when adding percentages

### DIFF
--- a/lib/nodes/unit.js
+++ b/lib/nodes/unit.js
@@ -126,7 +126,7 @@ Unit.prototype.operate = function(op, right){
   if (this.shouldCoerce(op)) {
     right = right.first;
     // percentages
-    if (('-' == op || '+' == op) && '%' == right.type) {
+    if ('%' != this.type && ('-' == op || '+' == op) && '%' == right.type) {
       right = new Unit(this.val * (right.val / 100), '%');
     } else {
       right = this.coerce(right);

--- a/test/cases/arithmetic.css
+++ b/test/cases/arithmetic.css
@@ -15,7 +15,8 @@ body {
   foo: 100%;
   foo: 75%;
   foo: 25%;
-  foo: 25%;
+  foo: 0%;
+  foo: 70%;
 }
 body {
   foo: 10em;

--- a/test/cases/arithmetic.styl
+++ b/test/cases/arithmetic.styl
@@ -23,6 +23,7 @@ body {
   foo: 50 + 50%;
   foo: 50 - 50%;
   foo: 50% - 50%;
+  foo: 50% + 20%;
 }
 body {
   foo: 5 + 5em;

--- a/test/cases/regression.834.css
+++ b/test/cases/regression.834.css
@@ -1,6 +1,6 @@
 .grid {
-  width: 45%;
+  width: 40%;
 }
 .grid {
-  width: 45%;
+  width: 40%;
 }

--- a/test/cases/regression.911.css
+++ b/test/cases/regression.911.css
@@ -1,4 +1,4 @@
 .foo {
   margin-left: 10%;
-  width: 55%;
+  width: 60%;
 }


### PR DESCRIPTION
What do you expect the result of `10% + 10%` to be? Well, everyone in
the world would say `20%`. Stylus thinks it should be `11%`.

Fixes learnboost/stylus#955
