### PR TITLE
Source Maps: Broken Paths. Fixes #1667

### DIFF
--- a/bin/stylus
+++ b/bin/stylus
@@ -402,6 +402,7 @@ var options = {
   , sourcemap: sourcemap
   , paths: [process.cwd()].concat(paths)
   , prefix: prefix
+  , dest: dest
 };
 
 // Buffer stdin
@@ -691,8 +692,8 @@ function writeFile(file, css) {
 function writeSourcemap(file, sourcemap) {
   // --out support
   var path = dest
-    ? join(dest, basename(file) + '.map')
-    : file + '.map';
+    ? join(dest, basename(file, '.styl') + '.css.map')
+    : file.replace(/\.styl$/i, '.css.map');
   fs.writeFile(path, JSON.stringify(sourcemap), function(err){
     if (err) throw err;
     console.log('  \033[90mgenerated\033[0m %s', path);

--- a/docs/sourcemaps.md
+++ b/docs/sourcemaps.md
@@ -9,7 +9,7 @@ permalink: docs/sourcemaps.html
 
 ## Create a sourcemap
 
-  Pass the `--sourcemap` flag (or `-m`) with a Stylus file. This will create a `style.css` file, and a `style.styl.map` file as siblings to your `style.styl` file and place a sourcemap link at the bottom of `style.css` to your sourcemap.
+  Pass the `--sourcemap` flag (or `-m`) with a Stylus file. This will create a `style.css` file, and a `style.css.map` file as siblings to your `style.styl` and place a sourcemap link at the bottom of `style.css` to your sourcemap.
 
   `stylus -m style.styl`
 

--- a/lib/visitor/sourcemapper.js
+++ b/lib/visitor/sourcemapper.js
@@ -11,6 +11,7 @@
 var Compiler = require('./compiler')
   , SourceMapGenerator = require('source-map').SourceMapGenerator
   , basename = require('path').basename
+  , join = require('path').join
   , relative = require('path').relative
   , sep = require('path').sep
   , fs = require('fs');
@@ -29,6 +30,7 @@ var SourceMapper = module.exports = function SourceMapper(root, options){
   this.lineno = 1;
   this.contents = {};
   this.filename = options.filename;
+  this.dest = options.dest;
 
   var sourcemap = options.sourcemap;
   this.basePath = sourcemap.basePath || '.';
@@ -57,7 +59,9 @@ SourceMapper.prototype.__proto__ = Compiler.prototype;
 var compile = Compiler.prototype.compile;
 SourceMapper.prototype.compile = function(){
   var css = compile.call(this)
-    , url = this.normalizePath(this.filename) + '.map'
+    , url = this.normalizePath(this.dest
+      ? join(this.dest, basename(this.filename, '.styl') + '.css.map')
+      : this.filename.replace(/\.styl$/i, '.css.map'))
     , map;
 
   if (this.inline) {
@@ -131,6 +135,7 @@ SourceMapper.prototype.move = function(str){
 
 SourceMapper.prototype.normalizePath = function(path){
   path = relative(this.basePath, path);
+  if (this.dest) path = relative(this.dest, path);
   if ('\\' == sep) {
     path = path.replace(/^[a-z]:\\/i, '/')
       .replace(/\\/g, '/');


### PR DESCRIPTION
- Fixed sourcemap paths when `--out` flag is present.
-  `.styl.map` => `.css.map`
