### PR TITLE
Allow plugins to be used in stylus.render options

### DIFF
--- a/docs/js.md
+++ b/docs/js.md
@@ -160,3 +160,11 @@ In this example, we define four functions: `add()`, `sub()`, `image-width()`, an
     stylus(str)
       .use(mylib)
       .render(...)
+
+  When calling the `render()` method with options, the `use` option can be given
+  a function or array of functions to be invoked with the renderer.
+
+    stylus.render(str, { use: mylib }, function(err, css){
+      if (err) throw err;
+      console.log(css);
+    });

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -36,6 +36,8 @@ function Renderer(str, options) {
   options = options || {};
   options.globals = options.globals || {};
   options.functions = options.functions || {};
+  options.use = options.use || [];
+  options.use = Array.isArray(options.use) ? options.use : [options.use];
   options.imports = [join(__dirname, 'functions')];
   options.paths = options.paths || [];
   options.filename = options.filename || 'stylus';
@@ -66,6 +68,12 @@ module.exports.events = events;
 
 Renderer.prototype.render = function(fn){
   var parser = this.parser = new Parser(this.str, this.options);
+
+  // use plugin(s)
+  for (var i = 0, len = this.options.use.length; i < len; i++) {
+    this.use(this.options.use[i]);
+  }
+
   try {
     nodes.filename = this.options.filename;
     // parse

--- a/test/run.js
+++ b/test/run.js
@@ -129,6 +129,24 @@ describe('JS API', function(){
       ).should.equal("body{foo:7;bar:foobar}");
   });
 
+  it('use plugin(s) from options object', function(){
+    var plugin = function(key, value) {
+      return function(style) {
+        style.define(key, new stylus.nodes.Literal(value));
+      }
+    };
+
+    stylus('body { foo: bar  }', {
+      compress: true,
+      use: plugin('bar', 'baz')
+    }).render().should.equal('body{foo:baz}');
+
+    stylus('body { foo: bar; foo: qux  }', {
+      compress: true,
+      use: [plugin('bar', 'baz'), plugin('qux', 'fred')]
+    }).render().should.equal('body{foo:baz;foo:fred}');
+  });
+
   it('import cloning with cache', function(){
     var path = __dirname + '/cases/import.basic/'
       , styl = readFile(path + 'clone.styl')


### PR DESCRIPTION
Allows a function or array of functions to be passed as the `use` option to `stylus.render`.

``` js
var plugin = function(key, value) {
  return function(style) {
    style.define(key, new stylus.nodes.Literal(value));
  }
};

stylus.render('body { foo: bar  }', {
  use: plugin('bar', 'baz')
});

// body { foo: baz }
```
