### PR TITLE
Adding mime-types for Woff2 + WebP to url()

### DIFF
--- a/lib/functions/url.js
+++ b/lib/functions/url.js
@@ -27,9 +27,11 @@ var defaultMimes = {
   , '.jpg': 'image/jpeg'
   , '.jpeg': 'image/jpeg'
   , '.svg': 'image/svg+xml'
+  , '.webp': 'image/webp'
   , '.ttf': 'application/x-font-ttf'
   , '.eot': 'application/vnd.ms-fontobject'
   , '.woff': 'application/font-woff'
+  , '.woff2': 'application/font-woff2'
 };
 
 /**


### PR DESCRIPTION
Adds mime-types for
- `.webp` image format
- `.woff2` font format

to the `url()` lib
