### PR TITLE
Added missing `vmax` unit

### DIFF
--- a/lib/units.js
+++ b/lib/units.js
@@ -9,7 +9,7 @@
 
 module.exports = [
     'em', 'ex', 'ch', 'rem' // relative lengths
-  , 'vw', 'vh', 'vmin' // relative viewport-percentage lengths
+  , 'vw', 'vh', 'vmin', 'vmax' // relative viewport-percentage lengths
   , 'cm', 'mm', 'in', 'pt', 'pc', 'px' // absolute lengths
   , 'deg', 'grad', 'rad', 'turn' // angles
   , 's', 'ms' // times


### PR DESCRIPTION
I discovered this issue when using the vmax unit in my own .styl, the resulting .css file had a space between the value and unit resulting in error producing CSS.
