### PR TITLE
Removed duplicate line in select clause, seems to fix a bug in downstream library

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -710,7 +710,6 @@ Parser.prototype = {
       case 'literal':
       case 'charset':
       case 'namespace':
-      case 'import':
       case 'require':
       case 'extend':
       case 'media':


### PR DESCRIPTION
This is one of the changes I had to make when integrating Stylus with the Grails Asset Pipeline ([this](https://github.com/gregopet/stylus-asset-pipeline) plugin).
