### PR TITLE
add optional in extend syntax

### DIFF
--- a/docs/extend.md
+++ b/docs/extend.md
@@ -185,3 +185,19 @@ Yielding:
     }
 
 Note that if the selector is not extended, it won't be in the resulting CSS, so it's a powerful way to create a library of extendable code. While you can insert code through mixins, they would insert the same code every time you use them, while extending placeholders would give you compact output.
+
+## Optional extending
+
+Sometimes it might be usefull to be able to extend something that might exists or not depending on the context. You can suffix any selector by `!optional` to achieve this:
+
+    $specialDesign
+      color: #FFF
+
+    .btn
+      @extend .design !optional, $specialDesign !optional
+
+Yielding:
+
+    .btn {
+      color: #fff;
+    }

--- a/lib/nodes/selector.js
+++ b/lib/nodes/selector.js
@@ -23,6 +23,7 @@ var Selector = module.exports = function Selector(segs){
   Node.call(this);
   this.inherits = true;
   this.segments = segs;
+  this.optional = false;
 };
 
 /**
@@ -39,7 +40,7 @@ Selector.prototype.__proto__ = Node.prototype;
  */
 
 Selector.prototype.toString = function(){
-  return this.segments.join('');
+  return this.segments.join('') + (this.optional ? ' !optional' : '');
 };
 
 /**
@@ -68,6 +69,7 @@ Selector.prototype.clone = function(parent){
   clone.inherits = this.inherits;
   clone.val = this.val;
   clone.segments = this.segments.map(function(node){ return node.clone(parent, clone); });
+  clone.optional = this.optional;
   return clone;
 };
 
@@ -83,6 +85,7 @@ Selector.prototype.toJSON = function(){
     __type: 'Selector',
     inherits: this.inherits,
     segments: this.segments,
+    optional: this.optional,
     val: this.val,
     lineno: this.lineno,
     column: this.column,

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -1073,12 +1073,25 @@ Parser.prototype = {
   extend: function(){
     var tok = this.expect('extend')
       , selectors = []
+      , sel
       , node
       , arr;
 
     do {
       arr = this.selectorParts();
-      if (arr.length) selectors.push(new nodes.Selector(arr));
+
+      if (!arr.length) continue;
+
+      sel = new nodes.Selector(arr);
+      selectors.push(sel);
+
+      if ('!' !== this.peek().type) continue;
+
+      tok = this.lookahead(2);
+      if ('ident' !== tok.type || 'optional' !== tok.val.name) continue;
+
+      this.skip(['!', 'ident']);
+      sel.optional = true;
     } while(this.accept(','));
 
     node = new nodes.Extend(selectors);

--- a/lib/visitor/evaluator.js
+++ b/lib/visitor/evaluator.js
@@ -835,6 +835,7 @@ Evaluator.prototype.visitExtend = function(extend){
       // Cloning the selector for when we are in a loop and don't want it to affect
       // the selector nodes and cause the values to be different to expected
       selector: this.interpolate(selector.clone()).trim(),
+      optional: selector.optional,
       lineno: selector.lineno,
       column: selector.column
     });

--- a/lib/visitor/normalizer.js
+++ b/lib/visitor/normalizer.js
@@ -378,6 +378,7 @@ Normalizer.prototype.extend = function(group, selectors){
   group.block.node.extends.forEach(function(extend){
     var groups = map[extend.selector];
     if (!groups) {
+      if (extend.optional) return;
       var err = new Error('Failed to @extend "' + extend.selector + '"');
       err.lineno = extend.lineno;
       err.column = extend.column;

--- a/test/cases/extend.with.optional.css
+++ b/test/cases/extend.with.optional.css
@@ -1,0 +1,13 @@
+.tester,
+.end {
+  color: #fff;
+}
+.end {
+  font-size: 12px;
+}
+.end {
+  border-radius: 1px;
+}
+.end {
+  border: #aaa;
+}

--- a/test/cases/extend.with.optional.styl
+++ b/test/cases/extend.with.optional.styl
@@ -1,0 +1,12 @@
+.tester
+  color #FFF
+
+$tester2
+  font-size 12px
+
+$tester3
+  border-radius 1px
+
+.end
+  @extend .tester !optional, notExist1 !optional, $notExist2 !optional, $tester2 !optional, {'$test' + 'er3'} !optional
+  border #AAA


### PR DESCRIPTION
This can be pretty useful in complex environments. Here is an example of the syntax:

``` stylus
$private
  color red

.myClass
  @extend $private !optional, $private2 !optional
```

This is inspired by http://sass-lang.com/documentation/file.SASS_REFERENCE.html#the__flag
