### PR TITLE
Fix resolve-url for hash url

### DIFF
--- a/lib/functions/resolver.js
+++ b/lib/functions/resolver.js
@@ -51,8 +51,8 @@ module.exports = function(options) {
       , res
       , found;
 
-    // Absolute
-    if (url.protocol) return literal;
+    // Absolute or hash
+    if (url.protocol || !url.pathname) return literal;
 
     // Lookup
     found = utils.lookup(url.pathname, paths, '', true);


### PR DESCRIPTION
Doesn't work compiling with resolve-url flag for hash url:

```
$ cat ../hash.styl
// For IE8. Doesn't work hover on padding.
.my-class
    background-image url('#')

$ bin/stylus --resolve-url ../hash.styl

/home/rakchaev/projects/stylus/bin/stylus:646
              throw err;
                    ^
TypeError: ../hash.styl:3:26
   1| // For IE8. Doesn't work hover on padding.
   2| .my-class
   3|   background-image url('#')
-------------------------------^
   4| 

Cannot call method 'substr' of null
    at ".my-class" (../hash.styl:2:1)
```
