### PR TITLE
Expose the AST by adding it to the render callback's arguments

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -135,7 +135,7 @@ form input {
 
 ### Authors
 
-  - [TJ Holowaychuk (visionmedia)](http://github.com/visionmedia)
+  - [TJ Holowaychuk (tj)](https://github.com/tj)
 
 ### More Information
 

--- a/docs/js.md
+++ b/docs/js.md
@@ -22,8 +22,18 @@ We can also do the same thing in a more progressive manner:
 
     stylus(str)
       .set('filename', 'nesting.css')
-      .render(function(err, css){
+      .render(function(err, css, ast){              
         // logic
+      });
+      
+You can also use/access Stylus' AST:
+
+    var stylus = require('stylus');
+
+    stylus(str)
+      .set('filename', 'nesting.css')
+      .render(function(err, css, ast){              
+        console.log( JSON.stringify( ast ) );
       });
 
 ## .set(setting, value)
@@ -52,7 +62,7 @@ Defer importing of the given `path` until evaluation is performed. The example b
       stylus(str)
         .set('filename', __dirname + '/test.styl')
         .import('mixins/vendor')
-        .render(function(err, css){
+        .render(function(err, css, ast){
         if (err) throw err;
         console.log(css);
       });
@@ -138,7 +148,7 @@ In this example, we define four functions: `add()`, `sub()`, `image-width()`, an
         .define('sub', sub)
         .define('image-width', imageWidth)
         .define('image-height', imageHeight)
-        .render(function(err, css){
+        .render(function(err, css, ast){
           if (err) throw err;
           console.log(css);
         });
@@ -164,7 +174,7 @@ In this example, we define four functions: `add()`, `sub()`, `image-width()`, an
   When calling the `render()` method with options, the `use` option can be given
   a function or array of functions to be invoked with the renderer.
 
-    stylus.render(str, { use: mylib }, function(err, css){
+    stylus.render(str, { use: mylib }, function(err, css, ast){
       if (err) throw err;
       console.log(css);
     });

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -75,7 +75,9 @@ Renderer.prototype.render = function(fn){
   }
 
   try {
+
     nodes.filename = this.options.filename;
+
     // parse
     var ast = parser.parse();
 
@@ -111,7 +113,7 @@ Renderer.prototype.render = function(fn){
   var listeners = this.listeners('end');
   if (fn) listeners.push(fn);
   for (var i = 0, len = listeners.length; i < len; i++) {
-    var ret = listeners[i](null, css);
+    var ret = listeners[i](null, css, ast);
     if (ret) css = ret;
   }
   if (!fn) return css;


### PR DESCRIPTION
This simple change makes a huge difference for other library authors and the community at large. By exposing the AST externally we are able to build better tools around Stylus as a language/parser.