### PR TITLE
Paths should be normalised

### DIFF
--- a/lib/functions/index.js
+++ b/lib/functions/index.js
@@ -200,7 +200,7 @@ exports.component = function component(color, name) {
 
 exports.basename = function basename(p, ext){
   utils.assertString(p, 'path');
-  return path.basename(p.val, ext && ext.val).replace(/\\/, '/');
+  return path.basename(p.val, ext && ext.val).replace(/\\/g, '/');
 };
 
 /**
@@ -213,7 +213,7 @@ exports.basename = function basename(p, ext){
 
 exports.dirname = function dirname(p){
   utils.assertString(p, 'path');
-  return path.dirname(p.val).replace(/\\/, '/');
+  return path.dirname(p.val).replace(/\\/g, '/');
 };
 
 /**
@@ -226,7 +226,7 @@ exports.dirname = function dirname(p){
 
 exports.extname = function extname(p){
   utils.assertString(p, 'path');
-  return path.extname(p.val).replace(/\\/, '/');
+  return path.extname(p.val).replace(/\\/g, '/');
 };
 
 /**
@@ -241,7 +241,7 @@ exports.extname = function extname(p){
   var paths = [].slice.call(arguments).map(function(path){
     return path.first.string;
   });
-  return path.join.apply(null, paths).replace(/\\/, '/');
+  return path.join.apply(null, paths).replace(/\\/g, '/');
 }).raw = true;
 
 /**

--- a/lib/functions/index.js
+++ b/lib/functions/index.js
@@ -200,7 +200,7 @@ exports.component = function component(color, name) {
 
 exports.basename = function basename(p, ext){
   utils.assertString(p, 'path');
-  return path.basename(p.val, ext && ext.val);
+  return path.basename(p.val, ext && ext.val).replace(/\\/, '/');
 };
 
 /**
@@ -213,7 +213,7 @@ exports.basename = function basename(p, ext){
 
 exports.dirname = function dirname(p){
   utils.assertString(p, 'path');
-  return path.dirname(p.val);
+  return path.dirname(p.val).replace(/\\/, '/');
 };
 
 /**
@@ -226,7 +226,7 @@ exports.dirname = function dirname(p){
 
 exports.extname = function extname(p){
   utils.assertString(p, 'path');
-  return path.extname(p.val);
+  return path.extname(p.val).replace(/\\/, '/');
 };
 
 /**
@@ -241,7 +241,7 @@ exports.extname = function extname(p){
   var paths = [].slice.call(arguments).map(function(path){
     return path.first.string;
   });
-  return path.join.apply(null, paths);
+  return path.join.apply(null, paths).replace(/\\/, '/');
 }).raw = true;
 
 /**


### PR DESCRIPTION
Paths should be normalized for windows support. As paths in windows return a format of \images\test.jpg - this not being web safe.