### PR TITLE
Fix middleware overlap function on windows.

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -122,7 +122,7 @@ module.exports = function(options){
       if (typeof dest == 'string') {
         // check for dest-path overlap
         var overlap = compare(dest, path).length;
-        if (sep == path.charAt(0)) overlap++;
+        if ('/' == path.charAt(0)) overlap++;
         path = path.slice(overlap);
       }
 
@@ -243,7 +243,7 @@ function checkImports(path, fn) {
 
 function compare(pathA, pathB) {
   pathA = pathA.split(sep);
-  pathB = pathB.split(sep);
+  pathB = pathB.split('/');
   if (!pathA[pathA.length - 1]) pathA.pop();
   if (!pathB[0]) pathB.shift();
   var overlap = [];
@@ -252,5 +252,5 @@ function compare(pathA, pathB) {
     overlap.push(pathA.pop());
     pathB.shift();
   }
-  return overlap.join(sep);
+  return overlap.join('/');
 }


### PR DESCRIPTION
The `compare` function was comparing file system paths, and url paths, but figuring out which separator to use based on the OS path separator `sep`.  This did not work on windows, and no overlap would be found because the url path never splits on `\\`.  

This fixes the compare function, and the part of the middleware that uses the overlap output so that the compare function translates the os path that might overlap with the url path into the correct path using a separator that can be compared to an url path.

This fixes windows compatibility, and unix/linux still works fine.

I will submit a test in a moment.

### Examples:


```
app.use(stylus.middleware({
  src: path.join(__dirname, 'stylus'),
  dest: path.join(__dirname, 'static', 'css')
}))

app.use(express.static(path.join(__dirname, 'static')))
```

This currently works on unix, and fails on windows. The path transforms to `/css/file.css` to `/file.css` on unix, but remains `/css/file.css` on windows, causing the middleware to not render it because there is no css folder in the stylus folder.