### PR TITLE
remove wrong selector in example

### DIFF
--- a/docs/extend.md
+++ b/docs/extend.md
@@ -116,7 +116,7 @@ permalink: docs/extend.html
    Yielding:
    
         form input[type=text],
-        form textarea {
+        textarea {
           padding: 5px;
           border: 1px solid #eee;
           color: #ddd;


### PR DESCRIPTION
The example seemed to indicate that the textarea would only inheriet styles while being a child of the form, which seemed off to me. Sure enough I compiled the example and got the expected output.