### PR TITLE
Fix bug with find absolute paths on windows

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -25,8 +25,8 @@ var nodes = require('./nodes')
  */
 
 exports.absolute = function(path){
-  // On Windows the path could start with a drive letter, i.e. a:\\ or two leading backslashes
-  return path.substr(0, 2) == '\\\\' || '/' === path.charAt(0) || /^[a-z]:\\/i.test(path);
+  // On Windows the path could start with a drive letter, i.e. a:\\ or two leading backslashes or a:/
+  return path.substr(0, 2) == '\\\\' || '/' === path.charAt(0) || /^[a-z]:[\\|/]/i.test(path);
 };
 
 /**


### PR DESCRIPTION
I use stylus-loader to webpack. In my config I want to use `import` feature to my variables, to allow import it to another files. It's work ok on UNIX systems, but on windows we found funny bug with message `failed to locate @import file C:/<path_to_file>`. As you see path to file is with revert slash. I do not believe it at first. At first I check path in my config. But in my config it was correct: `c:\`. Then I start debug stylus-loader and I found that in one step my slashes in my path revert. Hours of debugging give me solution: in util.found uses absolute function to check that file is absolute. I'm edit regexp and.. yeah! This work now for me. Node.js found file with revert slashes, and windows explorer accept such path well