### PR TITLE
Adding encoding types for data URL

### DIFF
--- a/lib/functions/url.js
+++ b/lib/functions/url.js
@@ -35,12 +35,19 @@ var defaultMimes = {
 };
 
 /**
+ * Default encoding.
+ */
+
+var defaultEncoding = 'base64';
+
+/**
  * Return a url() function with the given `options`.
  *
  * Options:
  *
  *    - `limit` bytesize limit defaulting to 30Kb
  *    - `paths` image resolution path(s), merged with general lookup paths
+ *    - `encoding` encoding data URLs
  *
  * Examples:
  *
@@ -60,6 +67,7 @@ module.exports = function(options) {
   var _paths = options.paths || [];
   var sizeLimit = null != options.limit ? options.limit : 30000;
   var mimes = options.mimes || defaultMimes;
+  var encoding = options.encoding || defaultEncoding;
 
   function fn(url){
     // Compile the url
@@ -104,7 +112,7 @@ module.exports = function(options) {
     if (false !== sizeLimit && buf.length > sizeLimit) return literal;
 
     // Encode
-    return new nodes.Literal('url("data:' + mime + ';base64,' + buf.toString('base64') + hash + '")');
+    return new nodes.Literal('url("data:' + mime + ';' +  encoding + ',' + buf.toString(encoding) + hash + '")');
   };
 
   fn.raw = true;


### PR DESCRIPTION


It would be very useful to change encoding types data url.

encoding: 'base64' (default)
```css
div {
    background: url('data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PSIwIDAgOCA4Ij48cGF0aCBkPSJNMCAwTDggMEw4IDgiLz48L3N2Zz4=');
}
```
encoding: 'utf8'
```css
div {
    background: url('data:image/svg+xml;utf8,<svg viewBox="0 0 8 8"><path d="M0 0L8 0L8 8"/></svg>');
}
```
It saves bytes for svg