### PR TITLE
Extend length method to work with strings

### DIFF
--- a/lib/functions/length.js
+++ b/lib/functions/length.js
@@ -14,6 +14,8 @@ var utils = require('../utils');
       var nodes = utils.unwrap(expr).nodes;
       if (1 == nodes.length && 'object' == nodes[0].nodeName) {
         return nodes[0].length;
+      } else if (1 == nodes.length && 'string' == nodes[0].nodeName) {
+        return nodes[0].val.length;
       } else {
         return nodes.length;
       }

--- a/test/cases/bifs.length.css
+++ b/test/cases/bifs.length.css
@@ -4,6 +4,7 @@ body {
   foo: 1;
   foo: 2;
   foo: 3;
+  foo: 3;
   foo: 4;
   foo: 5;
   foo: 6;

--- a/test/cases/bifs.length.styl
+++ b/test/cases/bifs.length.styl
@@ -13,6 +13,7 @@ body
   foo length(1)
   foo length((1 2) (3 4))
   foo length(1 2 3)
+  foo length("hey")
   foo vargs(1, 2, 3, 4)
   foo args(1 2 3 4 5)
   foo arguments(1,2,3,4,5,6)


### PR DESCRIPTION
Extends the length method to allow it to check string length as well; perhaps not terribly useful, but it seems odd to have a length method that doesn't work with a basic type that has a length property.

![](http://49.media.tumblr.com/tumblr_m38mt6XN8g1qk9g91o2_500.gif)
