### PR TITLE
Correct sourceMappingURL and sources paths

### DIFF
--- a/lib/visitor/sourcemapper.js
+++ b/lib/visitor/sourcemapper.js
@@ -147,7 +147,7 @@ SourceMapper.prototype.move = function(str){
  */
 
 SourceMapper.prototype.normalizePath = function(path){
-  path = relative(this.dest || this.basePath, path);
+  path = relative(this.basePath || this.dest, path);
   if ('\\' == sep) {
     path = path.replace(/^[a-z]:\\/i, '/')
       .replace(/\\/g, '/');

--- a/lib/visitor/sourcemapper.js
+++ b/lib/visitor/sourcemapper.js
@@ -70,9 +70,7 @@ var compile = Compiler.prototype.compile;
 SourceMapper.prototype.compile = function(){
   var css = compile.call(this)
     , out = this.basename + '.map'
-    , url = this.normalizePath(this.dest
-      ? join(this.dest, out)
-      : join(dirname(this.filename), out))
+    , url = this.normalizePath(join(dirname(this.filename), out))
     , map;
 
   if (this.inline) {


### PR DESCRIPTION
`sourceMappingURL` is for the browser to find the sourcemap from the given css. Since the path that the file is written to is always set to the out destination `+ '.map'` there is need to account for the dest when creating the url, otherwise you end up with it relative to the original source, and not the output css. 

The `--sourcemap-base` param is for specifying where the source files are relative to `--sourcemap-root`. This should take precedence over dest since the dest is just where the file is written to, it will not necessarily yield a path that is useful for the browser to resolve where the files are located as a url.

I think these are both relevant to issue #1669.
