### PR TITLE
Adds failing test

### DIFF
--- a/test/cases/selector.reference.css
+++ b/test/cases/selector.reference.css
@@ -84,6 +84,20 @@ foo /deep/ /deep/ {
 .foo:hover .bar {
   width: 20px;
 }
+.foo.on-foo {
+  width: 10px;
+}
+.foo--modifier.on-foo {
+  width: 20px;
+}
+.foo .child-of-foo,
+.foo .another-child-of-foo {
+  width: 10px;
+}
+.foo--modifier .child-of-foo,
+.foo--modifier .another-child-of-foo {
+  width: 20px;
+}
 .foo ^[ 0..5  ]:hover {
   color: #f00;
 }

--- a/test/cases/selector.reference.styl
+++ b/test/cases/selector.reference.styl
@@ -97,6 +97,16 @@ foo /deep/
 
     ^[0]:hover ^[1..-1]
       width: 20px
+.foo
+  &.on-foo
+    width: 10px
+    ^[0]--modifier^[1..-1]
+      width: 20px
+  & .child-of-foo
+  .another-child-of-foo
+    width: 10px
+    ^[0]--modifier^[1..-1]
+      width: 20px
 
 .foo
   \\^[ 0..5  ]:hover


### PR DESCRIPTION
Selector references don't always insert spaces when they should, assuming that I'm understanding the spec correctly.

Selectors that don't have any sort of explicit reference (`&`, `^[]`, `../`, etc) are given an implicit reference like this:

```styl
.foo
  // A selector without an explicit reference...
  .bar
  // ... is implicitly prefixed with `& ` (ampersand and space)
  & .bar
```

I assume that, since a space character is being specified between .bar and .foo, either explicitly or implicitly, it should be inserted into the rendered selector.  This doesn't always happen.