### PR TITLE
Fix typo in docs/bifs.md

### DIFF
--- a/docs/bifs.md
+++ b/docs/bifs.md
@@ -710,7 +710,7 @@ The third argument is optional and overrides the autodetected alpha.
        // => 'rgba'
 
        foo = convert('foo')
-       tyepof(foo)
+       typeof(foo)
        // => 'ident'
 
 ## s(fmt, ...)


### PR DESCRIPTION
`tyepof` => `typeof`