### PR TITLE
Validate this.dest before using path.extname

### DIFF
--- a/lib/visitor/sourcemapper.js
+++ b/lib/visitor/sourcemapper.js
@@ -38,7 +38,7 @@ var SourceMapper = module.exports = function SourceMapper(root, options){
   this.basePath = sourcemap.basePath || '.';
   this.inline = sourcemap.inline;
   this.comment = sourcemap.comment;
-  if (extname(this.dest) === '.css') {
+  if (this.dest && extname(this.dest) === '.css') {
     this.basename = basename(this.dest);
     this.dest = dirname(this.dest);
   } else {


### PR DESCRIPTION
In the current versions of node path.* can be called on any arbitrary value and will return an empty string on invalid input.

As of node v6 path will assert that values passed to it are strings, and as such will throw on `undefined`

This change adds an extra check to make sure path.extname
is not being called with an undefined value