### PR TITLE
Fix not watching files in windows

### DIFF
--- a/bin/stylus
+++ b/bin/stylus
@@ -750,9 +750,7 @@ function watch(file, rootFile) {
   // if is windows use fs.watch api instead
   // TODO: remove watchFile when fs.watch() works on osx etc
   if (isWindows) {
-    fs.watch(file, function(event) {
-      if (event === 'change') compile();
-    });
+    fs.watch(file, compile);
   } else {
     fs.watchFile(file, { interval: 300 }, function(curr, prev) {
       if (curr.mtime > prev.mtime) compile();


### PR DESCRIPTION
Fix isue https://github.com/stylus/stylus/issues/742 and another one error.
In Windows some java-based IDEs (IDEA, phpstorm, webstorm, netbeans) save files by renaming them. `fs.watch` return event as `'rename'`, not `'change'`. 
My solution is simply and ugly: do not check event type. So the new files are recompiled too.
