### PR TITLE
transparentify: Fixed sorting order for alpha

### DIFF
--- a/lib/functions/transparentify.js
+++ b/lib/functions/transparentify.js
@@ -36,7 +36,7 @@ module.exports = function transparentify(top, bottom, alpha){
   bottom = bottom.rgba;
   var bestAlpha = ['r', 'g', 'b'].map(function(channel){
     return (top[channel] - bottom[channel]) / ((0 < (top[channel] - bottom[channel]) ? 255 : 0) - bottom[channel]);
-  }).sort(function(a, b){return a < b;})[0];
+  }).sort(function(a, b){return b - a;})[0];
   if (alpha) {
     utils.assertType(alpha, 'unit', 'alpha');
     if ('%' == alpha.type) {


### PR DESCRIPTION
Pairs passed to `compareFn` of `Array.prototype.sort` is implementation specific. While
`node+v8` passes pairs in same order as array i.e. `a = i, b = i + 1`, Edge passes
it in reverse order i.e. `a = i + 1, b = i`. Because of this `node+chakracore` breaks in
`transparentify()` function when `bestAlpha` is sorted. The expectation is sort `bestAlpha`
in descending order and pick the hightest element (at index 0), `node+chakracore` sorts it in ascending order and gets the lowest element (at index 0).

Updated the `compareFn` to be more agnostic to the implementation of javascript engines.
Ran unit test on `node+v8` and `node+chakracore` and there is no new regression introduced.