### PR TITLE
fixed last property semicolon when compress is on

### DIFF
--- a/lib/visitor/compiler.js
+++ b/lib/visitor/compiler.js
@@ -120,9 +120,10 @@ Compiler.prototype.visitBlock = function(block){
     needBrackets = this.needBrackets(block.node);
 
     if (this.compress) {
-        for (var i = 0, len = block.nodes.length; i < len; ++i) {
+        for (var i = block.nodes.length - 1; i >= 0; --i) {
             if (block.nodes[i].nodeName === 'property') {
                 lastPropertyIndex = i;
+                break;
             }
         }
     }

--- a/lib/visitor/compiler.js
+++ b/lib/visitor/compiler.js
@@ -113,17 +113,25 @@ Compiler.prototype.visitRoot = function(block){
 Compiler.prototype.visitBlock = function(block){
   var node
     , separator = this.compress ? '' : '\n'
-    , needBrackets;
+    , needBrackets
+    , lastPropertyIndex;
 
   if (block.hasProperties && !block.lacksRenderedSelectors) {
     needBrackets = this.needBrackets(block.node);
 
+    if (this.compress) {
+        for (var i = 0, len = block.nodes.length; i < len; ++i) {
+            if (block.nodes[i].nodeName === 'property') {
+                lastPropertyIndex = i;
+            }
+        }
+    }
     if (needBrackets) {
       this.buf += this.out(this.compress ? '{' : ' {\n');
       ++this.indents;
     }
     for (var i = 0, len = block.nodes.length; i < len; ++i) {
-      this.last = len - 1 == i;
+      this.last = lastPropertyIndex === i;
       node = block.nodes[i];
       switch (node.nodeName) {
         case 'null':

--- a/test/cases/compress.semicolon.css
+++ b/test/cases/compress.semicolon.css
@@ -1,0 +1,1 @@
+.foo{foo:0;foo:0}.foo_bar{foo:0}

--- a/test/cases/compress.semicolon.styl
+++ b/test/cases/compress.semicolon.styl
@@ -1,0 +1,6 @@
+.foo
+  foo 0
+  foo 0
+
+  &_bar
+    foo 0


### PR DESCRIPTION
Fixed bug in evaluating last property when compress is on. There was an error in searching last property element in block.nodes (looking last element of list instead looking last property)