### PR TITLE
Fix bug when using 'constructor' in variables or loops

### DIFF
--- a/lib/stack/scope.js
+++ b/lib/stack/scope.js
@@ -35,7 +35,7 @@ Scope.prototype.add = function(ident){
  */
 
 Scope.prototype.lookup = function(name){
-  return this.locals[name];
+  return hasOwnProperty(this.locals, name) ? this.locals[name] : undefined;
 };
 
 /**
@@ -51,3 +51,12 @@ Scope.prototype.inspect = function(){
     + (keys.length ? ' ' + keys.join(', ') : '')
     + ']';
 };
+
+/**
+ * @param {Object} obj
+ * @param {String} propName
+ * @returns {Boolean}
+ */
+function hasOwnProperty(obj, propName) {
+  return Object.prototype.hasOwnProperty.call(obj, propName);
+}

--- a/test/cases/object-prototype-props.css
+++ b/test/cases/object-prototype-props.css
@@ -1,0 +1,8 @@
+body {
+  foo: constructor;
+}
+body {
+  foo: foo;
+  foo: constructor;
+  foo: hasOwnProperty;
+}

--- a/test/cases/object-prototype-props.styl
+++ b/test/cases/object-prototype-props.styl
@@ -1,0 +1,7 @@
+val = constructor
+body
+  foo val
+
+body
+  for val in foo constructor hasOwnProperty
+    foo val


### PR DESCRIPTION
The same for `hasOwnProperty`, `toString`, etc.

Current behavior:
styl:
```
val = constructor
body
  foo val
```
result:
```
body {
  foo: Object;
}
```

styl:
```
body
  for val in foo constructor
    foo val
```
result:
`Cannot read property 'name' of undefined`