### PR TITLE
Extend in block level import

### DIFF
--- a/lib/visitor/normalizer.js
+++ b/lib/visitor/normalizer.js
@@ -403,10 +403,13 @@ Normalizer.prototype.extend = function(group, selectors){
     var groups = map[extend.selector];
     if (!groups) {
       if (extend.optional) return;
-      var err = new Error('Failed to @extend "' + extend.selector + '"');
-      err.lineno = extend.lineno;
-      err.column = extend.column;
-      throw err;
+      groups = self._checkForPrefixedGroups(extend.selector);
+      if(!groups) {
+        var err = new Error('Failed to @extend "' + extend.selector + '"');
+        err.lineno = extend.lineno;
+        err.column = extend.column;
+        throw err;
+      }
     }
     selectors.forEach(function(selector){
       var node = new nodes.Selector;
@@ -421,4 +424,20 @@ Normalizer.prototype.extend = function(group, selectors){
   });
 
   group.block = this.visit(group.block);
+};
+
+Normalizer.prototype._checkForPrefixedGroups = function (selector) {
+  var prefix = [];
+  var map = this.map;
+  var result = null;
+  for (var i = 0; i < this.stack.length; i++) {
+    var stackElementArray=this.stack[i];
+    var stackElement = stackElementArray[0];
+    prefix.push(stackElement.val);
+    var fullSelector = prefix.join(" ") + " " + selector;
+    result = map[fullSelector];
+    if (result)
+      break;
+  }
+  return result;
 };

--- a/test/cases/extend.block-level.css
+++ b/test/cases/extend.block-level.css
@@ -1,0 +1,4 @@
+.theme .test-hello,
+.theme .test-world {
+  color: #f00;
+}

--- a/test/cases/extend.block-level.styl
+++ b/test/cases/extend.block-level.styl
@@ -1,0 +1,2 @@
+
+@import 'extend.block-level/b'

--- a/test/cases/extend.block-level/a.styl
+++ b/test/cases/extend.block-level/a.styl
@@ -1,0 +1,5 @@
+.test-hello
+    color #f00
+
+.test-world
+    @extend .test-hello

--- a/test/cases/extend.block-level/b.styl
+++ b/test/cases/extend.block-level/b.styl
@@ -1,0 +1,2 @@
+.theme
+    @import "a";


### PR DESCRIPTION
check in stack to find the extended group. allows for prefixed import to work.

fixes #1381