### PR TITLE
Make prefix-classes work with partial and range refs in selectors

### DIFF
--- a/lib/visitor/evaluator.js
+++ b/lib/visitor/evaluator.js
@@ -1418,7 +1418,7 @@ Evaluator.prototype.interpolate = function(node){
       case 'literal':
       case 'string':
         if (self.prefix && !node.prefixed && !node.val.nodeName) {
-          node.val = node.val.replace(/\./g, '.' + self.prefix);
+          node.val = node.val.replace(/\.(?=[\w-])|^\.$/g, '.' + self.prefix);
           node.prefixed = true;
         }
         return node.val;

--- a/test/cases/bifs.prefix-classes.css
+++ b/test/cases/bifs.prefix-classes.css
@@ -7,6 +7,18 @@
 .prefix-test2 {
   width: 1px;
 }
+.prefix-test {
+  width: 1px;
+}
+.prefix-test .prefix-test2 {
+  width: 1px;
+}
+.prefix-test .prefix-test3 {
+  color: #00f;
+}
+.prefix-test2 .prefix-test4 .prefix-test6 {
+  color: #008000;
+}
 .bar {
   width: 10px;
 }

--- a/test/cases/bifs.prefix-classes.styl
+++ b/test/cases/bifs.prefix-classes.styl
@@ -11,6 +11,18 @@ foo()
   .test2
     width: 1px
 
++prefix-classes('prefix-')
+  .test
+    width: 1px
+    .test2
+      width: 1px
+      ../ .test3
+        color: blue
+      .test4
+        .test5
+          ^[1..-2] .test6
+            color: green
+
 +foo()
   width: 10px
   +prefix-classes('prefix2-')


### PR DESCRIPTION
This PR solves #2194 by limiting the regex of the prefix-classes BIF to not match parent and partial references in selectors.