### PR TITLE
remove duplicate code

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -13,12 +13,6 @@ exports.ParseError = ParseError;
 exports.SyntaxError = SyntaxError;
 
 /**
- * Inherit from `Error.prototype`.
- */
-
-SyntaxError.prototype.__proto__ = Error.prototype;
-
-/**
  * Initialize a new `ParseError` with the given `msg`.
  *
  * @param {String} msg
@@ -55,4 +49,3 @@ function SyntaxError(msg) {
  */
 
 SyntaxError.prototype.__proto__ = Error.prototype;
-


### PR DESCRIPTION
The same line is repeated on (now) line 51. Also, should [this line](https://github.com/jonschlinkert/stylus/blob/0e5fda20434740e6e9a862432a4157ebbbc3bc0a/lib/errors.js#L44) be?

```diff
-Error.captureStackTrace(this, ParseError);
+Error.captureStackTrace(this, SyntaxError);
```