### PR TITLE
Add @insert "style.css" functionality

### DIFF
--- a/docs/import.md
+++ b/docs/import.md
@@ -3,7 +3,7 @@ layout: default
 permalink: docs/import.html
 ---
 
-# @import and @require
+# @import, @require, & @insert
 
 Stylus supports both literal __@import__ for CSS, as well as dynamic importing or requiring of other Stylus sheets.
 
@@ -60,6 +60,16 @@ Render the literal CSS __@import__ shown below:
 ## Require
 
 Along with `@import`, Stylus also has `@require`. It works almost in the same way, with the exception of importing any given file only once.
+
+## Insert
+
+Distinct from `@import` and `@require`, Stylus has `@insert`.  It works like a C preprocessor `#include`, inserting the text of the inserted CSS file directly into output.
+
+To insert the raw text of `reset.css`:
+
+     @insert "reset.css"
+
+The `@insert` line would then be replaced by the contents of `reset.css`, followed by a newline `\n`.
 
 ## Block-level import
 

--- a/lib/convert/css.js
+++ b/lib/convert/css.js
@@ -68,6 +68,7 @@ Converter.prototype.visit = function(node){
     case 'namespace':
     case 'media':
     case 'import':
+    case 'insert':
     case 'document':
     case 'keyframes':
     case 'page':
@@ -195,6 +196,19 @@ Converter.prototype.visitNamespace = function(node){
 
 Converter.prototype.visitImport = function(node){
   var buf = this.indent + '@import ' + node.import;
+  return buf + '\n';
+};
+
+/**
+ * Visit Insert `node`.`
+ *
+ * @param {Insert} node
+ * @return {String}
+ * @api private
+ */
+
+Converter.prototype.visitInsert = function(node){
+  var buf = this.indent + '@insert ' + node.import;
   return buf + '\n';
 };
 

--- a/lib/lexer.js
+++ b/lib/lexer.js
@@ -550,6 +550,7 @@ Lexer.prototype = {
         , tok;
       switch (type) {
         case 'require':
+        case 'insert':
         case 'import':
         case 'charset':
         case 'namespace':

--- a/lib/nodes/atrule.js
+++ b/lib/nodes/atrule.js
@@ -126,6 +126,7 @@ function hasOutput(block) {
       case 'property':
       case 'literal':
       case 'import':
+      case 'insert':
         return true;
       case 'block':
         return hasOutput(node);

--- a/lib/nodes/index.js
+++ b/lib/nodes/index.js
@@ -39,6 +39,7 @@ exports.Member = require('./member');
 exports.Charset = require('./charset');
 exports.Namespace = require('./namespace');
 exports.Import = require('./import');
+exports.Insert = require('./insert');
 exports.Extend = require('./extend');
 exports.Object = require('./object');
 exports.Function = require('./function');

--- a/lib/nodes/insert.js
+++ b/lib/nodes/insert.js
@@ -1,0 +1,68 @@
+
+/*!
+ * Stylus - Insert
+ * Copyright (c) Automattic <developer.wordpress.com>
+ * MIT Licensed
+ */
+
+/**
+ * Module dependencies.
+ */
+
+var Node = require('./node');
+
+/**
+ * Initialize a new `Insert` with the given `expr`.
+ *
+ * @param {Expression} expr
+ * @api public
+ */
+
+var Insert = module.exports = function Insert(expr, once){
+  Node.call(this);
+  this.path = expr;
+  this.once = once || false;
+};
+
+/**
+ * Inherit from `Node.prototype`.
+ */
+
+Insert.prototype.__proto__ = Node.prototype;
+
+/**
+ * Return a clone of this node.
+ *
+ * @return {Node}
+ * @api public
+ */
+
+Insert.prototype.clone = function(parent){
+  var clone = new Insert();
+  clone.path = this.path.nodeName ? this.path.clone(parent, clone) : this.path;
+  clone.once = this.once;
+  clone.mtime = this.mtime;
+  clone.lineno = this.lineno;
+  clone.column = this.column;
+  clone.filename = this.filename;
+  return clone;
+};
+
+/**
+ * Return a JSON representation of this node.
+ *
+ * @return {Object}
+ * @api public
+ */
+
+Insert.prototype.toJSON = function(){
+  return {
+    __type: 'Insert',
+    path: this.path,
+    once: this.once,
+    mtime: this.mtime,
+    lineno: this.lineno,
+    column: this.column,
+    filename: this.filename
+  };
+};

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -737,6 +737,7 @@ Parser.prototype = {
    *  | charset
    *  | namespace
    *  | import
+   *  | insert
    *  | require
    *  | media
    *  | atrule
@@ -764,6 +765,7 @@ Parser.prototype = {
       case 'charset':
       case 'namespace':
       case 'import':
+      case 'insert':
       case 'require':
       case 'extend':
       case 'media':
@@ -1263,6 +1265,16 @@ Parser.prototype = {
     this.expect('import');
     this.allowPostfix = true;
     return new nodes.Import(this.expression(), false);
+  },
+
+  /**
+   * insert expression
+   */
+
+  insert: function() {
+    this.expect('insert');
+    this.allowPostfix = true;
+    return new nodes.Insert(this.expression(), false);
   },
 
   /**

--- a/lib/visitor/compiler.js
+++ b/lib/visitor/compiler.js
@@ -177,6 +177,7 @@ Compiler.prototype.visitBlock = function(block){
         break;
       case 'media':
       case 'import':
+      case 'insert':
       case 'atrule':
       case 'supports':
         this.visit(node);
@@ -282,6 +283,22 @@ Compiler.prototype.visitFeature = function(node){
 
 Compiler.prototype.visitImport = function(imported){
   this.buf += this.out('@import ' + this.visit(imported.path) + ';\n', imported);
+};
+
+/**
+ * Visit Insert.
+ */
+
+Compiler.prototype.visitInsert = function(inserted){
+  var fs = require('fs');
+  var path = require('path');
+
+  var importer = inserted.filename;
+  var importee = inserted.path.nodes[0].val;
+
+  var pathname = path.resolve(path.dirname(importer), importee);
+
+  this.buf += this.out(fs.readFileSync(pathname) + '\n', inserted);
 };
 
 /**

--- a/lib/visitor/deps-resolver.js
+++ b/lib/visitor/deps-resolver.js
@@ -160,6 +160,12 @@ DepsResolver.prototype.visitImport = function(node) {
 };
 
 /**
+ * Visit Insert.
+ */
+
+DepsResolver.prototype.visitInsert = DepsResolver.prototype.visitImport;
+
+/**
  * Get dependencies.
  */
 

--- a/lib/visitor/normalizer.js
+++ b/lib/visitor/normalizer.js
@@ -16,7 +16,7 @@ var Visitor = require('./')
 /**
  * Initialize a new `Normalizer` with the given `root` Node.
  *
- * This visitor implements the first stage of the duel-stage
+ * This visitor implements the first stage of the dual-stage
  * compiler, tasked with stripping the "garbage" from
  * the evaluated nodes, ditching null rules, resolving
  * ruleset selectors etc. This step performs the logic
@@ -376,6 +376,12 @@ Normalizer.prototype.visitImport = function(node){
   this.imports.push(node);
   return this.hoist ? nodes.null : node;
 };
+
+/**
+ * Visit Insert.
+ */
+
+Normalizer.prototype.visitInsert = Normalizer.prototype.visitImport;
 
 /**
  * Visit Charset.

--- a/test/cases/insert.basic/oneline.css
+++ b/test/cases/insert.basic/oneline.css
@@ -1,0 +1,1 @@
+h2 { font-style: italic; }

--- a/test/cases/insert.basic/style.css
+++ b/test/cases/insert.basic/style.css
@@ -1,0 +1,3 @@
+body {
+  background: red;
+}

--- a/test/cases/insert.css
+++ b/test/cases/insert.css
@@ -1,0 +1,4 @@
+body {
+  background: red;
+}
+

--- a/test/cases/insert.repeated.css
+++ b/test/cases/insert.repeated.css
@@ -1,0 +1,3 @@
+h2 { font-style: italic; }
+h2 { font-style: italic; }
+h2 { font-style: italic; }

--- a/test/cases/insert.repeated.styl
+++ b/test/cases/insert.repeated.styl
@@ -1,0 +1,3 @@
+@insert "./insert.basic/oneline.css"
+@insert "./insert.basic/oneline.css"
+@insert "./insert.basic/oneline.css"

--- a/test/cases/insert.styl
+++ b/test/cases/insert.styl
@@ -1,0 +1,1 @@
+@insert "./insert.basic/style.css"


### PR DESCRIPTION
This adds a keyword like @import and @require that inserts the raw text of another file.

Paths are resolved relative to the file doing the importing.

This mostly resolves what #2155 was trying to solve.  Hopefully this at least moves the discussion forward.  I primarily just want to use this in my blog, so I've got a pretty specific usage and probably didn't capture every use case mentioned in that issue.  Feel free to do what you want with this request.

Thanks !