### PR TITLE
Use less confusing variable names

### DIFF
--- a/docs/variables.md
+++ b/docs/variables.md
@@ -21,10 +21,10 @@ Compiles to:
 Variables can even consist of an expression list:
 
     font-size = 14px
-    font = font-size "Lucida Grande", Arial
+    font-stack = "Lucida Grande", Arial, sans-serif
 
     body
-      font font, sans-serif
+      font font-size font-stack
 
 Compiles to:
 


### PR DESCRIPTION
Whilst the original shows how you can compose variables and mix this with other keywords to make a property declaration:
```
body
  font font, san-serif
```
This will be confusing to anyone unfamiliar with Stylus. It would also not be generally considered good practice to name a variable the same as the property it's applied to.

Theses possibilities and technicalities are better discovered later by more advanced users, than in the documentation on variables which is likely to be seen and used by every beginner.

Replaced with:
```
font-size = 14px
font-stack = "Lucida Grande", Arial, sans-serif

body
  font font-size font-stack
```