### PR TITLE
Update css

### DIFF
--- a/lib/convert/css.js
+++ b/lib/convert/css.js
@@ -75,6 +75,8 @@ Converter.prototype.visit = function(node){
     case 'supports':
       var name = node.type[0].toUpperCase() + node.type.slice(1);
       return this['visit' + name](node);
+    case 'font-face':
+      return this.visitFontFace(node);
   }
 };
 
@@ -93,6 +95,25 @@ Converter.prototype.visitRules = function(node){
   }
   return buf;
 };
+
+/**
+ * Visit FontFace `node`.
+ *
+ * @param {FontFace} node
+ * @return {String}
+ * @api private
+ */
+
+ Converter.prototype.visitFontFace = function(node){
+   var buf = this.indent + '@font-face';
+   buf += '\n';
+   ++this.indents;
+   for (var i = 0, len = node.declarations.length; i < len; ++i) {
+     buf += this.visitDeclaration(node.declarations[i]);
+   }
+   --this.indents;
+   return buf;
+ };
 
 /**
  * Visit Media `node`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,14 +7,18 @@
     "amdefine": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
-      "dev": true
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
     },
     "async": {
       "version": "0.2.10",
       "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
       "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
       "dev": true
+    },
+    "atob": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-1.1.3.tgz",
+      "integrity": "sha1-lfE2KbEsOlGl0hWr3OKqnzL4B3M="
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -59,10 +63,34 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
+    "css": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/css/-/css-2.2.1.tgz",
+      "integrity": "sha1-c6TIHehdtmTU7mdPfUcIXjstVdw=",
+      "requires": {
+        "inherits": "2.0.3",
+        "source-map": "0.1.43",
+        "source-map-resolve": "0.3.1",
+        "urix": "0.1.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.1.43",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+          "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
+          "requires": {
+            "amdefine": "1.0.1"
+          }
+        }
+      }
+    },
     "css-parse": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/css-parse/-/css-parse-1.7.0.tgz",
-      "integrity": "sha1-Mh9s9zeCpv91ERE5D8BeLGV9jJs="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/css-parse/-/css-parse-2.0.0.tgz",
+      "integrity": "sha1-pGjuZnwW2BzPBcWMONKpfHgNv9Q=",
+      "requires": {
+        "css": "2.2.1"
+      }
     },
     "debug": {
       "version": "3.1.0",
@@ -255,6 +283,11 @@
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
+    "resolve-url": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
+    },
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
@@ -315,9 +348,25 @@
       "dev": true
     },
     "source-map": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.1.tgz",
-      "integrity": "sha512-c+mPk+5wTnOd1y9oyVp0EQIo3N8k8gdxzxOo7jq1ApEN2+ew5c/UV+F1wtNHeS6Aa4JPsxiq5OU+95aMpRTGJA=="
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.2.tgz",
+      "integrity": "sha512-NDJB/R2BS7YJG0tP9SbE4DKwKj1idLT5RJqfVYZ7dreFX7wulZT3xxVhbYKrQo9n0JkRptl51TrX/5VK3HodMA=="
+    },
+    "source-map-resolve": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.3.1.tgz",
+      "integrity": "sha1-YQ9hIqRFuN1RU1oqcbeD38Ekh2E=",
+      "requires": {
+        "atob": "1.1.3",
+        "resolve-url": "0.2.1",
+        "source-map-url": "0.3.0",
+        "urix": "0.1.0"
+      }
+    },
+    "source-map-url": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.3.0.tgz",
+      "integrity": "sha1-fsrxO1e80J2opAxdJp2zN5nUqvk="
     },
     "supports-color": {
       "version": "4.4.0",
@@ -356,6 +405,11 @@
       "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
       "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
       "dev": true
+    },
+    "urix": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
     },
     "window-size": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -29,12 +29,12 @@
     "test-cov": "mocha test/ test/middleware/ --require should --bail --reporter html-cov > coverage.html"
   },
   "dependencies": {
-    "css-parse": "~1.7.0",
-    "mkdirp": "~0.5.x",
+    "css-parse": "~2.0.0",
     "debug": "~3.1.0",
-    "sax": "~1.2.4",
     "glob": "~7.1.2",
-    "source-map": "~0.7.1"
+    "mkdirp": "~0.5.x",
+    "sax": "~1.2.4",
+    "source-map": "~0.7.2"
   },
   "devDependencies": {
     "should": "~13.2.1",


### PR DESCRIPTION
I got security errors for old dependencies and decided to update them.

`parse-css` have added support for `@font-face`, so I added support for handling them when converting stylus –> CSS (test was failing).

@Panya could you review this, because I'm still studying the code. Thanks!