### PR TITLE
Fix: check whether captureStackTrace exists

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -22,7 +22,9 @@ exports.SyntaxError = SyntaxError;
 function ParseError(msg) {
   this.name = 'ParseError';
   this.message = msg;
-  Error.captureStackTrace(this, ParseError);
+  if (Error.captureStackTrace) {
+    Error.captureStackTrace(this, ParseError);
+  }
 }
 
 /**
@@ -41,7 +43,9 @@ ParseError.prototype.__proto__ = Error.prototype;
 function SyntaxError(msg) {
   this.name = 'SyntaxError';
   this.message = msg;
-  Error.captureStackTrace(this, ParseError);
+  if (Error.captureStackTrace) {
+    Error.captureStackTrace(this, ParseError);
+  }
 }
 
 /**

--- a/lib/nodes/node.js
+++ b/lib/nodes/node.js
@@ -23,7 +23,9 @@ var Evaluator = require('../visitor/evaluator')
 function CoercionError(msg) {
   this.name = 'CoercionError'
   this.message = msg
-  Error.captureStackTrace(this, CoercionError);
+  if (Error.captureStackTrace) {
+    Error.captureStackTrace(this, CoercionError);
+  }
 }
 
 /**


### PR DESCRIPTION
`captureStackTrace` is not available on Firefox. When running stylus on Firefox (try.html or browserified), errors can't be constructed. [MDN suggests checking it before use](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error#ES6_Custom_Error_Class).