### PR TITLE
Define function arguments explicitly

### DIFF
--- a/lib/functions/adjust.js
+++ b/lib/functions/adjust.js
@@ -10,7 +10,7 @@ var utils = require('../utils');
  * @api private
  */
 
-module.exports = function adjust(color, prop, amount){
+function adjust(color, prop, amount){
   utils.assertColor(color, 'color');
   utils.assertString(prop, 'prop');
   utils.assertType(amount, 'unit', 'amount');
@@ -26,3 +26,5 @@ module.exports = function adjust(color, prop, amount){
   hsl[prop] += val;
   return hsl.rgba;
 };
+adjust.params = ['color', 'prop', 'amount'];
+module.exports = adjust;

--- a/lib/functions/alpha.js
+++ b/lib/functions/alpha.js
@@ -22,7 +22,7 @@ var nodes = require('../nodes')
  * @api public
  */
 
-module.exports = function alpha(color, value){
+function alpha(color, value){
   color = color.rgba;
   if (value) {
     return rgba(
@@ -34,3 +34,5 @@ module.exports = function alpha(color, value){
   }
   return new nodes.Unit(color.a, '');
 };
+alpha.params = ['color', 'value'];
+module.exports = alpha;

--- a/lib/functions/basename.js
+++ b/lib/functions/basename.js
@@ -9,7 +9,9 @@ var utils = require('../utils')
  * @api public
  */
 
-module.exports = function basename(p, ext){
+function basename(p, ext){
   utils.assertString(p, 'path');
   return path.basename(p.val, ext && ext.val);
 };
+basename.params = ['p', 'ext'];
+module.exports = basename;

--- a/lib/functions/blend.js
+++ b/lib/functions/blend.js
@@ -21,7 +21,7 @@ var utils = require('../utils')
  * @api public
  */
 
-module.exports = function blend(top, bottom){
+function blend(top, bottom){
   // TODO: different blend modes like overlay etc.
   utils.assertColor(top);
   top = top.rgba;
@@ -35,3 +35,5 @@ module.exports = function blend(top, bottom){
     top.b * top.a + bottom.b * (1 - top.a),
     top.a + bottom.a - top.a * bottom.a);
 };
+blend.params = ['top', 'bottom'];
+module.exports = blend;

--- a/lib/functions/blue.js
+++ b/lib/functions/blue.js
@@ -19,7 +19,7 @@ var nodes = require('../nodes')
  * @api public
  */
 
-module.exports = function blue(color, value){
+function blue(color, value){
   color = color.rgba;
   if (value) {
     return rgba(
@@ -31,3 +31,5 @@ module.exports = function blue(color, value){
   }
   return new nodes.Unit(color.b, '');
 };
+blue.params = ['color', 'value'];
+module.exports = blue;

--- a/lib/functions/component.js
+++ b/lib/functions/component.js
@@ -48,7 +48,7 @@ var typeMap = {
  * @api public
  */
 
-module.exports = function component(color, name) {
+function component(color, name) {
   utils.assertColor(color, 'color');
   utils.assertString(name, 'name');
   var name = name.string
@@ -58,3 +58,5 @@ module.exports = function component(color, name) {
   if (!name) throw new Error('invalid color component "' + name + '"');
   return new nodes.Unit(color[type][name], unit);
 };
+component.params = ['color', 'name'];
+module.exports = component;

--- a/lib/functions/contrast.js
+++ b/lib/functions/contrast.js
@@ -22,7 +22,7 @@ var utils = require('../utils')
  * @api public
  */
 
-module.exports = function contrast(top, bottom){
+function contrast(top, bottom){
   if ('rgba' != top.nodeName && 'hsla' != top.nodeName) {
     return new nodes.Literal('contrast(' + (top.isNull ? '' : top.toString()) + ')');
   }
@@ -73,3 +73,5 @@ module.exports = function contrast(top, bottom){
   }
   return result;
 }
+contrast.params = ['top', 'bottom'];
+module.exports = contrast;

--- a/lib/functions/convert.js
+++ b/lib/functions/convert.js
@@ -9,7 +9,9 @@ var utils = require('../utils');
  * @api public
  */
 
-module.exports = function convert(str){
+function convert(str){
   utils.assertString(str, 'str');
   return utils.parseString(str.string);
 };
+convert.params = ['str'];
+module.exports = convert;

--- a/lib/functions/define.js
+++ b/lib/functions/define.js
@@ -10,7 +10,7 @@ var utils = require('../utils')
  * @api public
  */
 
-module.exports = function define(name, expr, global){
+function define(name, expr, global){
   utils.assertType(name, 'string', 'name');
   expr = utils.unwrap(expr);
   var scope = this.currentScope;
@@ -21,3 +21,5 @@ module.exports = function define(name, expr, global){
   scope.add(node);
   return nodes.null;
 };
+define.params = ['name', 'expr', 'global'];
+module.exports = define;

--- a/lib/functions/dirname.js
+++ b/lib/functions/dirname.js
@@ -9,7 +9,9 @@ var utils = require('../utils')
  * @api public
  */
 
-module.exports = function dirname(p){
+function dirname(p){
   utils.assertString(p, 'path');
   return path.dirname(p.val).replace(/\\/g, '/');
 };
+dirname.params = ['p'];
+module.exports = dirname;

--- a/lib/functions/error.js
+++ b/lib/functions/error.js
@@ -7,9 +7,11 @@ var utils = require('../utils');
  * @api public
  */
 
-module.exports = function error(msg){
+function error(msg){
   utils.assertType(msg, 'string', 'msg');
   var err = new Error(msg.val);
   err.fromStylus = true;
   throw err;
 };
+error.params = ['msg'];
+module.exports = error;

--- a/lib/functions/extname.js
+++ b/lib/functions/extname.js
@@ -9,7 +9,9 @@ var utils = require('../utils')
  * @api public
  */
 
-module.exports = function extname(p){
+function extname(p){
   utils.assertString(p, 'path');
   return path.extname(p.val);
 };
+extname.params = ['p'];
+module.exports = extname;

--- a/lib/functions/green.js
+++ b/lib/functions/green.js
@@ -19,7 +19,7 @@ var nodes = require('../nodes')
  * @api public
  */
 
-module.exports = function green(color, value){
+function green(color, value){
   color = color.rgba;
   if (value) {
     return rgba(
@@ -31,3 +31,5 @@ module.exports = function green(color, value){
   }
   return new nodes.Unit(color.g, '');
 };
+green.params = ['color', 'value'];
+module.exports = green;

--- a/lib/functions/hsl.js
+++ b/lib/functions/hsl.js
@@ -21,7 +21,7 @@ var utils = require('../utils')
  * @api public
  */
 
-module.exports = function hsl(hue, saturation, lightness){
+function hsl(hue, saturation, lightness){
   if (1 == arguments.length) {
     utils.assertColor(hue, 'color');
     return hue.hsla;
@@ -33,3 +33,5 @@ module.exports = function hsl(hue, saturation, lightness){
       , new nodes.Unit(1));
   }
 };
+hsl.params = ['hue', 'saturation', 'lightness'];
+module.exports = hsl;

--- a/lib/functions/hsla.js
+++ b/lib/functions/hsla.js
@@ -21,7 +21,7 @@ var utils = require('../utils')
  * @api public
  */
 
-module.exports = function hsla(hue, saturation, lightness, alpha){
+function hsla(hue, saturation, lightness, alpha){
   switch (arguments.length) {
     case 1:
       utils.assertColor(hue);
@@ -51,3 +51,5 @@ module.exports = function hsla(hue, saturation, lightness, alpha){
         , alpha.val);
   }
 };
+hsla.params = ['hue', 'saturation', 'lightness', 'alpha'];
+module.exports = hsla;

--- a/lib/functions/hue.js
+++ b/lib/functions/hue.js
@@ -20,7 +20,7 @@ var nodes = require('../nodes')
  * @api public
  */
 
-module.exports = function hue(color, value){
+function hue(color, value){
   if (value) {
     var hslaColor = color.hsla;
     return hsla(
@@ -32,3 +32,5 @@ module.exports = function hue(color, value){
   }
   return component(color, new nodes.String('hue'));
 };
+hue.params = ['color', 'value'];
+module.exports = hue;

--- a/lib/functions/image-size.js
+++ b/lib/functions/image-size.js
@@ -32,7 +32,7 @@ var utils = require('../utils')
  * @api public
  */
 
-module.exports = function imageSize(img, ignoreErr) {
+function imageSize(img, ignoreErr) {
   utils.assertType(img, 'string', 'img');
   try {
     var img = new Image(this, img.string);
@@ -56,3 +56,5 @@ module.exports = function imageSize(img, ignoreErr) {
 
   return expr;
 };
+imageSize.params = ['img', 'ignoreErr'];
+module.exports = imageSize;

--- a/lib/functions/json.js
+++ b/lib/functions/json.js
@@ -35,7 +35,7 @@ var utils = require('../utils')
  * @api public
 */
 
-module.exports = function(path, local, namePrefix){
+function json(path, local, namePrefix){
   utils.assertString(path, 'path');
 
   // lookup
@@ -79,6 +79,8 @@ module.exports = function(path, local, namePrefix){
     return ret;
   }
 };
+json.params = ['path', 'local', 'namePrefix'];
+module.exports = json;
 
 /**
  * Old `json` BIF.

--- a/lib/functions/lightness.js
+++ b/lib/functions/lightness.js
@@ -20,7 +20,7 @@ var nodes = require('../nodes')
  * @api public
  */
 
-module.exports = function lightness(color, value){
+function lightness(color, value){
   if (value) {
     var hslaColor = color.hsla;
     return hsla(
@@ -32,3 +32,5 @@ module.exports = function lightness(color, value){
   }
   return component(color, new nodes.String('lightness'));
 };
+lightness.params = ['color', 'value'];
+module.exports = lightness;

--- a/lib/functions/lookup.js
+++ b/lib/functions/lookup.js
@@ -9,9 +9,11 @@ var utils = require('../utils')
  * @api public
  */
 
-module.exports = function lookup(name){
+function lookup(name){
   utils.assertType(name, 'string', 'name');
   var node = this.lookup(name.val);
   if (!node) return nodes.null;
   return this.visit(node);
-};
+}
+lookup.params = ['name'];
+module.exports = lookup;

--- a/lib/functions/luminosity.js
+++ b/lib/functions/luminosity.js
@@ -21,7 +21,7 @@ var utils = require('../utils')
  * @api public
  */
 
-module.exports = function luminosity(color){
+function luminosity(color){
   utils.assertColor(color);
   color = color.rgba;
   function processChannel(channel) {
@@ -36,3 +36,5 @@ module.exports = function luminosity(color){
     + 0.0722 * processChannel(color.b)
   );
 };
+luminosity.params = ['color'];
+module.exports = luminosity;

--- a/lib/functions/match.js
+++ b/lib/functions/match.js
@@ -24,12 +24,14 @@ var VALID_FLAGS = 'igm';
  * @api public
  */
 
-module.exports = function match(pattern, val, flags){
+function match(pattern, val, flags){
   utils.assertType(pattern, 'string', 'pattern');
   utils.assertString(val, 'val');
   var re = new RegExp(pattern.val, validateFlags(flags) ? flags.string : '');
   return val.string.match(re);
-};
+}
+match.params = ['pattern', 'val', 'flags'];
+module.exports = match;
 
 function validateFlags(flags) {
   flags = flags && flags.string;

--- a/lib/functions/math-prop.js
+++ b/lib/functions/math-prop.js
@@ -8,6 +8,8 @@ var nodes = require('../nodes');
  * @api private
  */
 
-module.exports = function math(prop){
+function math(prop){
   return new nodes.Unit(Math[prop.string]);
-};
+}
+math.params = ['prop'];
+module.exports = math;

--- a/lib/functions/math.js
+++ b/lib/functions/math.js
@@ -10,8 +10,10 @@ var utils = require('../utils')
  * @api private
  */
 
-module.exports = function math(n, fn){
+function math(n, fn){
   utils.assertType(n, 'unit', 'n');
   utils.assertString(fn, 'fn');
   return new nodes.Unit(Math[fn.string](n.val), n.type);
-};
+}
+math.params = ['n', 'fn'];
+module.exports = math;

--- a/lib/functions/operate.js
+++ b/lib/functions/operate.js
@@ -10,9 +10,11 @@ var utils = require('../utils');
  * @api public
  */
 
-module.exports = function operate(op, left, right){
+function operate(op, left, right){
   utils.assertType(op, 'string', 'op');
   utils.assertPresent(left, 'left');
   utils.assertPresent(right, 'right');
   return left.operate(op.val, right);
-};
+}
+operate.params = ['op', 'left', 'right'];
+module.exports = operate;

--- a/lib/functions/prefix-classes.js
+++ b/lib/functions/prefix-classes.js
@@ -9,7 +9,7 @@ var utils = require('../utils');
  * @api private
  */
 
-module.exports = function prefixClasses(prefix, block){
+function prefixClasses(prefix, block){
   utils.assertString(prefix, 'prefix');
   utils.assertType(block, 'block', 'block');
 
@@ -19,4 +19,6 @@ module.exports = function prefixClasses(prefix, block){
   block = this.visit(block);
   this.options.prefix = this.prefix = _prefix;
   return block;
-};
+}
+prefixClasses.params = ['prefix', 'block'];
+module.exports = prefixClasses;

--- a/lib/functions/range.js
+++ b/lib/functions/range.js
@@ -13,7 +13,7 @@ var utils = require('../utils')
  * @api public
  */
 
-module.exports = function range(start, stop, step){
+function range(start, stop, step){
   utils.assertType(start, 'unit', 'start');
   utils.assertType(stop, 'unit', 'stop');
   if (step) {
@@ -29,4 +29,6 @@ module.exports = function range(start, stop, step){
     list.push(new nodes.Unit(i, start.type));
   }
   return list;
-};
+}
+range.params = ['start', 'stop', 'step'];
+module.exports = range;

--- a/lib/functions/red.js
+++ b/lib/functions/red.js
@@ -19,7 +19,7 @@ var nodes = require('../nodes')
  * @api public
  */
 
-module.exports = function red(color, value){
+function red(color, value){
   color = color.rgba;
   if (value) {
     return rgba(
@@ -30,4 +30,6 @@ module.exports = function red(color, value){
     );
   }
   return new nodes.Unit(color.r, '');
-};
+}
+red.params = ['color', 'value'];
+module.exports = red;

--- a/lib/functions/remove.js
+++ b/lib/functions/remove.js
@@ -9,9 +9,11 @@ var utils = require('../utils');
  * @api public
  */
 
-module.exports = function remove(object, key){
+function remove(object, key){
   utils.assertType(object, 'object', 'object');
   utils.assertString(key, 'key');
   delete object.vals[key.string];
   return object;
-};
+}
+remove.params = ['object', 'key'];
+module.exports = remove;

--- a/lib/functions/replace.js
+++ b/lib/functions/replace.js
@@ -11,7 +11,7 @@ var utils = require('../utils')
  * @api public
  */
 
-module.exports = function replace(pattern, replacement, val){
+function replace(pattern, replacement, val){
   utils.assertString(pattern, 'pattern');
   utils.assertString(replacement, 'replacement');
   utils.assertString(val, 'val');
@@ -20,4 +20,6 @@ module.exports = function replace(pattern, replacement, val){
   return val instanceof nodes.Ident
     ? new nodes.Ident(res)
     : new nodes.String(res);
-};
+}
+replace.params = ['pattern', 'replacement', 'val'];
+module.exports = replace;

--- a/lib/functions/rgb.js
+++ b/lib/functions/rgb.js
@@ -20,7 +20,7 @@ var utils = require('../utils')
  * @api public
  */
 
-module.exports = function rgb(red, green, blue){
+function rgb(red, green, blue){
   switch (arguments.length) {
     case 1:
       utils.assertColor(red);
@@ -37,4 +37,6 @@ module.exports = function rgb(red, green, blue){
         , blue
         , new nodes.Unit(1));
   }
-};
+}
+rgb.params = ['red', 'green', 'blue'];
+module.exports = rgb;

--- a/lib/functions/rgba.js
+++ b/lib/functions/rgba.js
@@ -23,7 +23,7 @@ var utils = require('../utils')
  * @api public
  */
 
-module.exports = function rgba(red, green, blue, alpha){
+function rgba(red, green, blue, alpha){
   switch (arguments.length) {
     case 1:
       utils.assertColor(red);
@@ -56,4 +56,6 @@ module.exports = function rgba(red, green, blue, alpha){
         , b
         , alpha.val);
   }
-};
+}
+rgba.params = ['red', 'green', 'blue', 'alpha'];
+module.exports = rgba;

--- a/lib/functions/saturation.js
+++ b/lib/functions/saturation.js
@@ -20,7 +20,7 @@ var nodes = require('../nodes')
  * @api public
  */
 
-module.exports = function saturation(color, value){
+function saturation(color, value){
   if (value) {
     var hslaColor = color.hsla;
     return hsla(
@@ -31,5 +31,6 @@ module.exports = function saturation(color, value){
     )
   }
   return component(color, new nodes.String('saturation'));
-};
-
+}
+saturation.params = ['color', 'value'];
+module.exports = saturation;

--- a/lib/functions/selector-exists.js
+++ b/lib/functions/selector-exists.js
@@ -8,7 +8,7 @@ var utils = require('../utils');
  * @api public
  */
 
-module.exports = function selectorExists(sel) {
+function selectorExists(sel) {
   utils.assertString(sel, 'selector');
 
   if (!this.__selectorsMap__) {
@@ -20,4 +20,6 @@ module.exports = function selectorExists(sel) {
   }
 
   return sel.string in this.__selectorsMap__;
-};
+}
+selectorExists.params = ['sel'];
+module.exports = selectorExists;

--- a/lib/functions/split.js
+++ b/lib/functions/split.js
@@ -10,7 +10,7 @@ var utils = require('../utils')
  * @api public
  */
 
-module.exports = function split(delim, val){
+function split(delim, val){
   utils.assertString(delim, 'delimiter');
   utils.assertString(val, 'val');
   var splitted = val.string.split(delim.string);
@@ -22,4 +22,6 @@ module.exports = function split(delim, val){
     expr.nodes.push(new ItemNode(splitted[i]));
   }
   return expr;
-};
+}
+split.params = ['delim', 'val'];
+module.exports = split;

--- a/lib/functions/substr.js
+++ b/lib/functions/substr.js
@@ -11,7 +11,7 @@ var utils = require('../utils')
  * @api public
  */
 
-module.exports = function substr(val, start, length){
+function substr(val, start, length){
   utils.assertString(val, 'val');
   utils.assertType(start, 'unit', 'start');
   length = length && length.val;
@@ -19,4 +19,6 @@ module.exports = function substr(val, start, length){
   return val instanceof nodes.Ident
       ? new nodes.Ident(res)
       : new nodes.String(res);
-};
+}
+substr.params = ['val', 'start', 'length'];
+module.exports = substr;

--- a/lib/functions/tan.js
+++ b/lib/functions/tan.js
@@ -9,7 +9,7 @@ var utils = require('../utils')
  * @api public
  */
 
-module.exports = function tan(angle) {
+function tan(angle) {
   utils.assertType(angle, 'unit', 'angle');
 
   var radians = angle.val;
@@ -25,4 +25,6 @@ module.exports = function tan(angle) {
     , tan = Math.round(m * sin / cos ) / m;
 
   return new nodes.Unit(tan, '');
-};
+}
+tan.params = ['angle'];
+module.exports = tan;

--- a/lib/functions/transparentify.js
+++ b/lib/functions/transparentify.js
@@ -23,7 +23,7 @@ var utils = require('../utils')
  * @api public
  */
 
-module.exports = function transparentify(top, bottom, alpha){
+function transparentify(top, bottom, alpha){
   utils.assertColor(top);
   top = top.rgba;
   // Handle default arguments
@@ -61,3 +61,5 @@ module.exports = function transparentify(top, bottom, alpha){
     Math.round(bestAlpha * 100) / 100
   );
 }
+transparentify.params = ['top', 'bottom', 'alpha'];
+module.exports = transparentify;

--- a/lib/functions/type.js
+++ b/lib/functions/type.js
@@ -24,7 +24,9 @@ var utils = require('../utils');
  * @api public
  */
 
-module.exports = function type(node){
+function type(node){
   utils.assertPresent(node, 'expression');
   return node.nodeName;
-};
+}
+type.params = ['node'];
+module.exports = type;

--- a/lib/functions/unit.js
+++ b/lib/functions/unit.js
@@ -10,7 +10,7 @@ var utils = require('../utils')
  * @api public
  */
 
-module.exports = function unit(unit, type){
+function unit(unit, type){
   utils.assertType(unit, 'unit', 'unit');
 
   // Assign
@@ -20,4 +20,6 @@ module.exports = function unit(unit, type){
   } else {
     return unit.type || '';
   }
-};
+}
+unit.params = ['unit', 'type'];
+module.exports = unit;

--- a/lib/functions/unquote.js
+++ b/lib/functions/unquote.js
@@ -17,7 +17,9 @@ var utils = require('../utils')
  * @api public
  */
 
-module.exports = function unquote(string){
+function unquote(string){
   utils.assertString(string, 'string');
   return new nodes.Literal(string.string);
-};
+}
+unquote.params = ['string'];
+module.exports = unquote;

--- a/lib/functions/use.js
+++ b/lib/functions/use.js
@@ -12,7 +12,7 @@ var utils = require('../utils')
 *     // => width: 110
 */
 
-module.exports = function use(plugin, options){
+function use(plugin, options){
   utils.assertString(plugin, 'plugin');
 
   if (options) {
@@ -31,7 +31,9 @@ module.exports = function use(plugin, options){
     throw new Error('plugin "' + plugin + '" does not export a function');
   }
   this.renderer.use(fn(options || this.options));
-};
+}
+use.params = ['plugin', 'options'];
+module.exports = use;
 
 /**
  * Attempt to parse object node to the javascript object.

--- a/lib/functions/warn.js
+++ b/lib/functions/warn.js
@@ -8,8 +8,10 @@ var utils = require('../utils')
  * @api public
  */
 
-module.exports = function warn(msg){
+function warn(msg){
   utils.assertType(msg, 'string', 'msg');
   console.warn('Warning: %s', msg.val);
   return nodes.null;
-};
+}
+warn.params = ['msg'];
+module.exports = warn;

--- a/lib/visitor/evaluator.js
+++ b/lib/visitor/evaluator.js
@@ -1030,7 +1030,10 @@ Evaluator.prototype.invokeBuiltin = function(fn, args){
   if (fn.raw) {
     args = args.nodes;
   } else {
-    args = utils.params(fn).reduce(function(ret, param){
+    if (!fn.params) {
+      fn.params = utils.params(fn);
+    }
+    args = fn.params.reduce(function(ret, param){
       var arg = args.map[param] || args.nodes.shift()
       if (arg) {
         arg = utils.unwrap(arg);


### PR DESCRIPTION
If we compile Stylus through a compressor supporting variable name mangling (e.g. terser), Stylus would fail to handle [keyword arguments](http://stylus-lang.com/docs/kwargs.html) because they are extracted from the source code.

This PR defines a `params` property to store function arguments. `utils.params` is called if this property doesn't exist.

See also: https://github.com/openstyles/stylus-lang-bundle/issues/3