### PR TITLE
Fix no such directory error in Stylus Executable

### DIFF
--- a/bin/stylus
+++ b/bin/stylus
@@ -11,7 +11,8 @@ var fs = require('fs')
   , extname = require('path').extname
   , resolve = require('path').resolve
   , join = require('path').join
-  , isWindows = process.platform === 'win32';
+  , isWindows = process.platform === 'win32'
+  , mkdirp = require('mkdirp');
 
 /**
  * Arguments.
@@ -711,6 +712,7 @@ function writeFile(file, css) {
   // --print support
   if (print) return process.stdout.write(css);
   var path = createPath(file);
+  mkdirp.sync(dirname(path), function(err){ if (err) throw err; })
   fs.writeFile(path, css, function(err){
     if (err) throw err;
     console.log('  \033[90mcompiled\033[0m %s', path);
@@ -725,6 +727,7 @@ function writeFile(file, css) {
 
 function writeSourcemap(file, sourcemap) {
   var path = createPath(file, true);
+  mkdirp.sync(dirname(path), function(err){ if (err) throw err; })
   fs.writeFile(path, JSON.stringify(sourcemap), function(err){
     if (err) throw err;
     // don't output log message if --print is present


### PR DESCRIPTION
Currently, Stylus Executable isn't creating necessary subdirectories for `--out` option.
This causes `Error: ENOENT: no such file or directory` error when specifying not existing subdirectories.
Fortunately, `mkdirp` is used for `middleware.js` and stylus already have it in dependencies.

I added `mkdirp.sync()` in compiling/generating file function for prevent no such file or directory error.
In my test run, it seems working with no errors!