### PR TITLE
Fix maths for lib/functions/adjust()

### DIFF
--- a/lib/functions/adjust.js
+++ b/lib/functions/adjust.js
@@ -18,10 +18,8 @@ module.exports = function adjust(color, prop, amount){
   prop = { hue: 'h', saturation: 's', lightness: 'l' }[prop.string];
   if (!prop) throw new Error('invalid adjustment property');
   var val = amount.val;
-  if ('%' == amount.type){
-    val = 'l' == prop && val > 0
-      ? (100 - hsl[prop]) * val / 100
-      : hsl[prop] * (val / 100);
+  if ('%' == amount.type && 'l' == prop){
+    val = hsl[prop] * (val / 100);
   }
   hsl[prop] += val;
   return hsl.rgba;

--- a/test/cases/arithmetic.color.css
+++ b/test/cases/arithmetic.color.css
@@ -7,8 +7,8 @@ body {
   foo: #ba3a3a;
 }
 body {
-  foo: #d06969;
-  foo: #d06969;
+  foo: #d16c6c;
+  foo: #d16c6c;
 }
 body {
   foo: #a13333;


### PR DESCRIPTION
The calculation of the returned value is awkward in case of a percentage of lightness.
However, as this error is here since quite a long time, fixing will surely break stuff...

Sorry about the double PR... :/

------

Take `hsl.l = 60`. Increasing it's value of 50% should give as a result 90%, and 30% when decreasing it.
The decreasing part is OK, however increasing the lightness by 50% gives 80%.

The current code, when used with percentages and lightness is equivalent to:
```
if ( val > 0 ) {
    val = (100 - hsl[prop]) * val / 100
} else {
    val = hsl[prop] * (val / 100);
}
hsl[prop] += val;
```

Numerically, with values as given above (`val = 50`, `hsl.l = 60`):
```
if ( val > 0 ) {
    val = (100 - 60) * 50 / 100 = 20;
} else {
    val = 60 * (50 / 100) = 30; /* Or = -30 ; as if we are here, val < 0 */
}
```
Thus, if we want to have 90% as a result, only the `else` part is valid.