### PR TITLE
Fixed define column  for mixin

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -1775,7 +1775,9 @@ Parser.prototype = {
    */
 
   functionDefinition: function() {
-    var name = this.expect('function').val.name;
+    var
+      tok = this.expect('function'),
+      name = tok.val.name;
 
     // params
     this.state.push('function params');
@@ -1788,6 +1790,10 @@ Parser.prototype = {
     // Body
     this.state.push('function');
     var fn = new nodes.Function(name, params);
+
+    fn.column = tok.column;
+    fn.lineno = tok.lineno;
+
     fn.block = this.block(fn);
     this.state.pop();
     return new nodes.Ident(name, fn);


### PR DESCRIPTION
Sometimes the parser remembers the element column incorrectly. This is important for sourcemap and for linters.