### PR TITLE
Patched Renderer.deps() to recognize identifiers as import paths.

### DIFF
--- a/lib/visitor/deps-resolver.js
+++ b/lib/visitor/deps-resolver.js
@@ -110,7 +110,7 @@ DepsResolver.prototype.visitCall = function(call) {
  */
 
 DepsResolver.prototype.visitImport = function(node) {
-  var path = node.path.first.val
+  var path = !node.path.first.val.isNull && node.path.first.val || node.path.first.name
     , literal, found, oldPath;
 
   if (!path) return;

--- a/test/deps-resolver/using_identifiers.deps
+++ b/test/deps-resolver/using_identifiers.deps
@@ -1,0 +1,3 @@
+test/deps-resolver/using_identifiers/main.styl
+test/deps-resolver/using_identifiers/_Styling.styl
+test/deps-resolver/using_identifiers/_ExtraStyling.styl

--- a/test/deps-resolver/using_identifiers.styl
+++ b/test/deps-resolver/using_identifiers.styl
@@ -1,0 +1,1 @@
+@import 'using_identifiers/main'

--- a/test/deps-resolver/using_identifiers/_ExtraStyling.styl
+++ b/test/deps-resolver/using_identifiers/_ExtraStyling.styl
@@ -1,0 +1,2 @@
+body
+  content: "ExtraStyling"

--- a/test/deps-resolver/using_identifiers/_Styling.styl
+++ b/test/deps-resolver/using_identifiers/_Styling.styl
@@ -1,0 +1,4 @@
+body
+  content: "Styling"
+
+@import _ExtraStyling

--- a/test/deps-resolver/using_identifiers/main.styl
+++ b/test/deps-resolver/using_identifiers/main.styl
@@ -1,0 +1,4 @@
+@import _Styling
+
+body
+  content: "main"


### PR DESCRIPTION
Hey maintainers, I believe I found some inconsistent behavior in the way Stylus's Renderer.render() and Renderer.deps() looks for dependency files.

I'm currently working on unofficially updated forks of:
* [electron-forge](https://github.com/LanetheGreat/electron-forge)
* [electron-prebuilt-compile](https://github.com/LanetheGreat/electron-prebuilt-compile)
* [electron-compile](https://github.com/LanetheGreat/electron-compile)
* [electron-compilers](https://github.com/LanetheGreat/electron-compilers)

And trying to maintain the "buildless" system that the developers at Electron-Userland abandoned and came across this bug while trying to add dependency output for [electron-compilers](https://github.com/LanetheGreat/electron-compilers) to use in unit tests for the repo. I'm using the [milligram framework](https://milligram.io/) (which conveniently built multiple packages of their framework in [LESS](https://github.com/milligram/milligram-less), [SASS](https://github.com/milligram/milligram-sass)/[SCSS](https://github.com/milligram/milligram-scss), [minified CSS](https://github.com/milligram/milligram), and [Stylus](https://github.com/milligram/milligram-stylus)) to unit test all of the CSS compilers, but when testing Stylus it'd successfully render milligram into CSS but when calling `.deps()` it would always give an error of either `null` or an object being passed to the path library.

Some debugging later and I found out that milligram was using `@import _ExampleDependency` without quotes around the file names instead of `@import '_ExampleDependency'`, which Stylus is interpreting as identifier nodes (Ident) whose `.val` is a Null node internally, instead of a string node (String) whose `.val` is actually the string used in the file's syntax. So I'm not fully sure how `.render()` is interpreting the syntax correctly, but this PR fixes `.deps()` and makes it consistent with `.render()`. I've also added a unit test based off of the existing 'basic' test already under '[test/deps-resolver](https://github.com/stylus/stylus/tree/dev/test/deps-resolver)' to check for the missing behavior in `.deps()`.

I've also attached an example snippet to demonstrate the inconsistency using [milligram-stylus](https://npmjs.org/package/milligram-stylus). I've tested this on v0.54.7 and the dev branch using Node 8 and 10 on both Linux and Windows.
```javascript
const fs = require('fs');
const path = require('path');
const stylus = require('.');
const filePath = path.posix.join('node_modules', 'milligram-stylus', 'dist', 'milligram.styl')

console.log(stylus(fs.readFileSync(filePath, 'utf-8')).set('filename', filePath).render())
console.log(stylus(fs.readFileSync(filePath, 'utf-8')).set('filename', filePath).deps())
```
Steps to demonstrate behavior:
* Clone stylus, and `npm install`
* Run `npm install --no-save milligram-stylus`
* Save the code snippet into the project's root folder as `test-deps.js`.
* Run `node test-deps.js`

It'll show milligram compiled, and then error when gathering its dependencies.

