### PR TITLE
Fixed an issue when running Stylus inside of an .asar archive

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -38,7 +38,7 @@ function Renderer(str, options) {
   options.functions = options.functions || {};
   options.use = options.use || [];
   options.use = Array.isArray(options.use) ? options.use : [options.use];
-  options.imports = [join(__dirname, 'functions')].concat(options.imports || []);
+  options.imports = [join(__dirname, 'functions/index.styl')].concat(options.imports || []);
   options.paths = options.paths || [];
   options.filename = options.filename || 'stylus';
   options.Evaluator = options.Evaluator || Evaluator;


### PR DESCRIPTION
Could not figure out why the importer resolves the wrong path when stylus is run inside of an asar archive but putting an absolute path fixes the issue.  https://github.com/electron/asar