### PR TITLE
Fix for Node v14 'Accessing non-existent property' errors

### DIFF
--- a/lib/nodes/index.js
+++ b/lib/nodes/index.js
@@ -5,6 +5,10 @@
  * MIT Licensed
  */
 
+exports.lineno = null;
+exports.column = null;
+exports.filename = null;
+
 /**
  * Constructors
  */


### PR DESCRIPTION
Fix for issue https://github.com/stylus/stylus/issues/2534

## Why it happens
`lib/nodes/index.js` performs `new exports.Boolean(true)` which reads `nodes.lineno`. Since `lineno` is missing in `lib/nodes`, node.js outputs warnings. Same is for properties `column` and `filename`.

## How to reproduce
With node v14:
```
npm install stylus
node
> require('stylus')
```

It will output
```
(node:117248) Warning: Accessing non-existent property 'lineno' of module exports inside circular dependency
(Use `node --trace-warnings ...` to show where the warning was created)
(node:117248) Warning: Accessing non-existent property 'column' of module exports inside circular dependency
(node:117248) Warning: Accessing non-existent property 'filename' of module exports inside circular dependency
(node:117248) Warning: Accessing non-existent property 'lineno' of module exports inside circular dependency
(node:117248) Warning: Accessing non-existent property 'column' of module exports inside circular dependency
(node:117248) Warning: Accessing non-existent property 'filename' of module exports inside circular dependency
```

## 1. Make sure you have tests for your modifications.
Are tests needed for this fix? If so what should they check?


