### PR TITLE
Bug fixes of encoding png image in `url` lib function

### DIFF
--- a/lib/functions/url.js
+++ b/lib/functions/url.js
@@ -114,19 +114,19 @@ module.exports = function(options) {
     }
 
     // Read data
-    var str = fs.readFileSync(found, 'utf8');
+    buf = fs.readFileSync(found);
 
     // Too large
-    if(false !== sizeLimit && str.length > sizeLimit) return literal;
+    if(false !== sizeLimit && buf.length > sizeLimit) return literal;
 
     if(enc && 'utf8' == enc.first.val.toLowerCase()) {
       encoding = encodingTypes.UTF8;
-      result = str.replace(/\s+/g, ' ')
+      result = buf.toString().replace(/\s+/g, ' ')
         .replace(/[{}\|\\\^~\[\]`"<>#%]/g, function(match) {
           return '%' + match[0].charCodeAt(0).toString(16).toUpperCase();
         }).trim();
     } else {
-      result = Buffer.from(str.replace(/\r\n?/g, '\n')).toString(encoding) + hash;
+      result = buf.toString(encoding) + hash;
     }
 
     // Encode


### PR DESCRIPTION
[These changes](https://github.com/stylus/stylus/pull/2523/files#diff-99f8176d3af5093bc2a6bacd47b01659L117-R129) breaks the base64 encoding of png images.

Related PR and discussion: https://github.com/stylus/stylus/issues/2546#issuecomment-667134391

---

1x1px png for testing: http://1x1px.me/000000-0.8.png

### stylus 0.54.8

__got the wrong result:__

```
data:image/png;base64,77+9UE5HChoKAAAACklIRFIAAAABAAAAAQgEAAAA77+9HAwCAAAAC0lEQVR477+9Y2I4AwAA77+9AM+Z77+9TlUAAAAASUVORO+/vUJg77+9
```

`Buffer.from(buf.toString().replace(/\r\n?/g, '\n')))`:

```
<Buffer ef bf bd 50 4e 47 0a 1a 0a 00 00 00 0a 49 48 44 52 00 00 00 01 00 00 00 01 08 04 00 00 00 ef bf bd 1c 0c 02 00 00 00 0b 49 44 41 54 78 ef bf bd 63 62 ... 31 more bytes>
```

### stylus 0.54.7 or include this PR

__got the correct result:__

base64:

```
data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGNiOAMAANUAz5n+TlUAAAAASUVORK5CYII=
```

`buf`:

```
<Buffer 89 50 4e 47 0d 0a 1a 0a 00 00 00 0d 49 48 44 52 00 00 00 01 00 00 00 01 08 04 00 00 00 b5 1c 0c 02 00 00 00 0b 49 44 41 54 78 9c 63 62 38 03 00 00 d5 ... 18 more bytes>
```