### PR TITLE
Added support for Tailwind CSS variants to @apply

### DIFF
--- a/lib/lexer.js
+++ b/lib/lexer.js
@@ -191,6 +191,25 @@ Lexer.prototype = {
   },
 
   /**
+   * Check if the current token is inside of a TailwindCSS @apply directive.
+   *
+   * @return {Boolean}
+   * @api private
+   */
+
+  isInsideOfTailwindApply: function() {
+      for(let i = this.stash.length - 1; 0 <= i; i--) {
+        var token = this.stash[i];
+        if(token.type == 'ident' && token.val && token.val.name == '@apply')
+          return true;
+        if(token.type == 'space' || token.type == 'ident')
+          continue;
+        return false;
+      }
+      return false;
+  },
+
+  /**
    * Fetch next token.
    *
    * @return {Token}
@@ -669,6 +688,15 @@ Lexer.prototype = {
 
   ident: function() {
     var captures;
+
+    // Is this a TailwindCSS variant:utility inside of @apply directive?
+    if (captures = /^[a-z][a-z0-9-]+:[a-z][-a-z0-9]+(?=[\s;]|$)/.exec(this.str)) {
+      if (this.isInsideOfTailwindApply()) {
+        this.skip(captures);
+        return new Token('ident', new nodes.Ident(captures[0]));
+      }
+    }
+
     if (captures = /^-*([_a-zA-Z$]|@apply)[-\w\d$]*/.exec(this.str)) {
       this.skip(captures);
       return new Token('ident', new nodes.Ident(captures[0]));

--- a/test/cases/tailwind-apply.css
+++ b/test/cases/tailwind-apply.css
@@ -1,0 +1,6 @@
+.tailwind-no-variants {
+  @apply bg-blue-700 text-orange-200;
+}
+.tailwind-variants {
+  @apply bg-white sm:bg-red-100 focus:font-black;
+}

--- a/test/cases/tailwind-apply.styl
+++ b/test/cases/tailwind-apply.styl
@@ -1,0 +1,5 @@
+.tailwind-no-variants
+  @apply bg-blue-700 text-orange-200
+
+.tailwind-variants
+  @apply bg-white sm:bg-red-100 focus:font-black


### PR DESCRIPTION
Stylus emits an error when a developer attempts to use [variants](https://tailwindcss.com/docs/configuring-variants) inside of Tailwind's [@apply directive](https://tailwindcss.com/docs/functions-and-directives#apply).

This PR fixes that issue.