### PR TITLE
Add deg and fr as exceptions for 0 value unit omission

### DIFF
--- a/lib/visitor/compiler.js
+++ b/lib/visitor/compiler.js
@@ -414,7 +414,7 @@ Compiler.prototype.visitUnit = function(unit){
   // Compress
   if (this.compress) {
     // Always return '0' unless the unit is a percentage, time, degree or fraction
-    if ('%' != type && 's' != type && 'ms' != type && 'deg' != type && 'fr' != type && 0 == n) return '0';
+    if (!(['%', 's', 'ms', 'deg', 'fr'].includes(type)) && 0 == n) return '0';
     // Omit leading '0' on floats
     if (float && n < 1 && n > -1) {
       return n.toString().replace('0.', '.') + type;

--- a/lib/visitor/compiler.js
+++ b/lib/visitor/compiler.js
@@ -413,8 +413,8 @@ Compiler.prototype.visitUnit = function(unit){
 
   // Compress
   if (this.compress) {
-    // Always return '0' unless the unit is a percentage or time
-    if ('%' != type && 's' != type && 'ms' != type && 0 == n) return '0';
+    // Always return '0' unless the unit is a percentage, time, degree or fraction
+    if ('%' != type && 's' != type && 'ms' != type && 'deg' != type && 'fr' != type && 0 == n) return '0';
     // Omit leading '0' on floats
     if (float && n < 1 && n > -1) {
       return n.toString().replace('0.', '.') + type;

--- a/test/cases/compress.units.css
+++ b/test/cases/compress.units.css
@@ -1,1 +1,1 @@
-body{foo:0;foo:0;foo:15;foo:-15;foo:15px;foo:-15px}body{foo:.1;foo:-.1;foo:1.1;foo:-1.1;foo:.1;foo:-.1;foo:10.1;foo:-10.1}body{foo:0s;foo:0ms}
+body{foo:0;foo:0;foo:15;foo:-15;foo:15px;foo:-15px}body{foo:.1;foo:-.1;foo:1.1;foo:-1.1;foo:.1;foo:-.1;foo:10.1;foo:-10.1}body{foo:0s;foo:0ms}body{foo:0deg;foo:15deg;foo:-15deg}body{foo:0fr;foo:15fr;foo:-15fr}

--- a/test/cases/compress.units.styl
+++ b/test/cases/compress.units.styl
@@ -19,3 +19,13 @@ body
 body
   foo 0s
   foo 0ms
+
+body
+  foo 0deg
+  foo 15deg
+  foo -15deg
+
+body
+  foo 0fr
+  foo 15fr
+  foo -15fr


### PR DESCRIPTION
Fix #2570 where `fr` and `deg` units are omitted when `--compress` is on, which results in invalid CSS.