### PR TITLE
chore: add macos platform test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     name: 'Test stylus on ${{matrix.os}} with node${{matrix.node}}'
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         # Latest four Nodejs LTS version
         node: [10, 12, 14, 16]
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Try add macos test.

<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: add macos platform test

<!-- Why are these changes necessary? -->

**Why**: Many stylus developer use macos as daily development platform, make sure it run ok on macos. That's all

<!-- How were these changes implemented? -->

**How**: add `macos-latest` in ci.yml file

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Unit Tests
- [ ] Code complete

<!-- feel free to add additional comments -->
