### PR TITLE
Fix: `@import` url() error in dependency resolver

### DIFF
--- a/lib/visitor/deps-resolver.js
+++ b/lib/visitor/deps-resolver.js
@@ -110,6 +110,9 @@ DepsResolver.prototype.visitCall = function(call) {
  */
 
 DepsResolver.prototype.visitImport = function(node) {
+  // If it's a url() call, skip
+  if (node.path.first.name === 'url') return;
+
   var path = !node.path.first.val.isNull && node.path.first.val || node.path.first.name
     , literal, found, oldPath;
 

--- a/test/deps-resolver/url.deps
+++ b/test/deps-resolver/url.deps
@@ -1,0 +1,2 @@
+test/deps-resolver/url/a.styl
+test/deps-resolver/url/b.styl

--- a/test/deps-resolver/url.styl
+++ b/test/deps-resolver/url.styl
@@ -1,0 +1,1 @@
+@import 'url/a'

--- a/test/deps-resolver/url/a.styl
+++ b/test/deps-resolver/url/a.styl
@@ -1,0 +1,2 @@
+@import url('https://example.com')
+@import 'b'

--- a/test/deps-resolver/url/b.styl
+++ b/test/deps-resolver/url/b.styl
@@ -1,0 +1,1 @@
+@import url('http://foo.com/some.styl')


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Fixes #2595 

<!-- Why are these changes necessary? -->

**Why**: Because `@import url()` returns an error for the `.deps()` / `--deps` flag

<!-- How were these changes implemented? -->

**How**: Add a check to `DepsResolver.prototype.visitImport` to skip `url()` imports from dependency resolver, and thus from dependency lists

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Unit Tests
- [x] Code complete

<!-- feel free to add additional comments -->

**Comments**
- It may be argued whether `url()` should or should not be included in the deps list (the documentation is not explicit about this) - however I've opted to skip them from the deps list, since they'll be almost necessarily external to the consumer codebase
- Replaces #2627, as that solution causes other bugs in unit tests