### PR TITLE
Fix: Unquoted `url()` data URL values that contain `+`

### DIFF
--- a/lib/lexer.js
+++ b/lib/lexer.js
@@ -285,7 +285,7 @@ Lexer.prototype = {
   urlchars: function() {
     var captures;
     if (!this.isURL) return;
-    if (captures = /^[\/:@.;?&=*!,<>#%0-9]+/.exec(this.str)) {
+    if (captures = /^\+[a-z]+/.exec(this.str) ? /^[\/:@.;?&+=*!,<>#%0-9]+/.exec(this.str) : /^[\/:@.;?&=*!,<>#%0-9]+/.exec(this.str)) {
       this.skip(captures);
       return new Token('literal', new nodes.Literal(captures[0]));
     }

--- a/test/cases/regression.2597.css
+++ b/test/cases/regression.2597.css
@@ -1,0 +1,6 @@
+.icon-search {
+  mask-image: url("data:image/svg+xml,%3Csvg%20width%3D%2224%22%20height%3D%2224%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20d%3D%22M16.31%2015.561l4.114%204.115-.848.848-4.123-4.123a7%207%200%2011.857-.84zM16.8%2011a5.8%205.8%200%2010-11.6%200%205.8%205.8%200%200011.6%200z%22%20fill-rule%3D%22evenodd%22%2F%3E%3C%2Fsvg%3E");
+}
+.icon-search {
+  mask-image: url("data:image/svg+xml,%3Csvg%20width%3D%2224%22%20height%3D%2224%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20d%3D%22M16.31%2015.561l4.114%204.115-0.848.848-4.123-4.123a7%207%200%2011.857-0.84zM16.8%2011a5.8%205.8%200%2010-11.6%200%205.8%205.8%200%200011.6%200z%22%20fill-rule%3D%22evenodd%22%2F%3E%3C%2Fsvg%3E");
+}

--- a/test/cases/regression.2597.styl
+++ b/test/cases/regression.2597.styl
@@ -1,0 +1,5 @@
+.icon-search
+  mask-image url("data:image/svg+xml,%3Csvg%20width%3D%2224%22%20height%3D%2224%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20d%3D%22M16.31%2015.561l4.114%204.115-.848.848-4.123-4.123a7%207%200%2011.857-.84zM16.8%2011a5.8%205.8%200%2010-11.6%200%205.8%205.8%200%200011.6%200z%22%20fill-rule%3D%22evenodd%22%2F%3E%3C%2Fsvg%3E")
+
+.icon-search
+  mask-image url(data:image/svg+xml,%3Csvg%20width%3D%2224%22%20height%3D%2224%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20d%3D%22M16.31%2015.561l4.114%204.115-.848.848-4.123-4.123a7%207%200%2011.857-.84zM16.8%2011a5.8%205.8%200%2010-11.6%200%205.8%205.8%200%200011.6%200z%22%20fill-rule%3D%22evenodd%22%2F%3E%3C%2Fsvg%3E)


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Closes #2597 

<!-- Why are these changes necessary? -->

**Why**: A value of `url(data:image/svg+xml)` without `'` or `"` produces a parse error `illegal unary "%", missing left-hand operand` - however, unquoted style is acceptable CSS3 syntax, so it should work in Stylus as well.

<!-- How were these changes implemented? -->

**How**: Unlike the error message would suggest, the culprit is **not** the `%` in the URL, but instead it's the `+` in `svg+xml` - this makes Stylus think it's an expression, like in the `bifs.url` test:

https://github.com/stylus/stylus/blob/9cb7635af60bf918ed8c2a990efd251e2e825975/test/cases/bifs.url.styl#L10-L13

I modified the the `urlchars` method in the lexer to accept `+` as urlchars, but only when the current `str` begins with a `+` and letters (otherwise the BIF test above would fail). At this point of parsing, the `str` would look like `+xml,...` so it's a fair guess that we have been parsing a data URL mimetype.

However, this methodology isn't completely foolproof (i.e. it doesn't actually _check_ that we're parsing a `data:` URL specifically), and although all the tests do currently pass, there is a chance this may cause other unintended edge case regressions.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Unit Tests
- [x] Code complete

<!-- feel free to add additional comments -->
