### PR TITLE
Make the "--quiet" flag more effective

### DIFF
--- a/bin/stylus
+++ b/bin/stylus
@@ -739,7 +739,7 @@ function writeFile(file, css) {
 
   fs.writeFile(path, css, function(err){
     if (err) throw err;
-    console.log('  \033[90mcompiled\033[0m %s', path);
+    if (!quiet) console.log('  \033[90mcompiled\033[0m %s', path);
     // --watch support
     watch(file, file);
   });
@@ -757,7 +757,7 @@ function writeSourcemap(file, sourcemap) {
   fs.writeFile(path, JSON.stringify(sourcemap), function(err){
     if (err) throw err;
     // don't output log message if --print is present
-    if (!print) console.log('  \033[90mgenerated\033[0m %s', path);
+    if (!print && !quiet) console.log('  \033[90mgenerated\033[0m %s', path);
   });
 }
 


### PR DESCRIPTION
**What**: silence the output of the "generated/compiled" messages when the `--quiet` flag is used on the command line.

**Why**: when using the `--quiet` flag, I expect that no message is printed on the standard output. Currently, only the "watching" message is removed when using this flag.

**How**: before printing to the standard output, the `quiet` variable is checked to be `false`.

**Checklist**:
- [x] Documentation: N/A
- [x] Unit Tests: N/A
- [x] Code complete: N/A