### PR TITLE
Fix 2699 : filename set at parsing stage + nodes.filename scope + filename in the `Root` AST node

### DIFF
--- a/lib/nodes/root.js
+++ b/lib/nodes/root.js
@@ -18,6 +18,7 @@ var Node = require('./node');
  */
 
 var Root = module.exports = function Root(){
+  Node.call(this);
   this.nodes = [];
 };
 

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -161,7 +161,15 @@ var Parser = module.exports = function Parser(str, options) {
     this.lexer = new Lexer(str, options);
   }
   this.prefix = options.prefix || '';
-  this.root = options.root || new nodes.Root;
+  this.filename = options.filename || null;
+  var previousFilename = nodes.filename;
+  nodes.filename = options.filename;
+  try{
+    this.root = options.root || new nodes.Root;
+  }
+  finally{
+    nodes.filename = previousFilename;
+  }
   this.state = ['root'];
   this.stash = [];
   this.parens = 0;
@@ -227,23 +235,29 @@ Parser.prototype = {
    */
 
   parse: function(){
-    var block = this.parent = this.root;
-    if (Parser.cache.has(this.hash)) {
-      block = Parser.cache.get(this.hash);
-      // normalize cached imports
-      if ('block' == block.nodeName) block.constructor = nodes.Root;
-    } else {
-      while ('eos' != this.peek().type) {
-        this.skipWhitespace();
-        if ('eos' == this.peek().type) break;
-        var stmt = this.statement();
-        this.accept(';');
-        if (!stmt) this.error('unexpected token {peek}, not allowed at the root level');
-        block.push(stmt);
+    var previousFilename = nodes.filename;
+    nodes.filename = this.filename;
+    try{
+      var block = this.parent = this.root;
+      if (Parser.cache.has(this.hash)) {
+        block = Parser.cache.get(this.hash);
+        // normalize cached imports
+        if ('block' == block.nodeName) block.constructor = nodes.Root;
+      } else {
+        while ('eos' != this.peek().type) {
+          this.skipWhitespace();
+          if ('eos' == this.peek().type) break;
+          var stmt = this.statement();
+          this.accept(';');
+          if (!stmt) this.error('unexpected token {peek}, not allowed at the root level');
+          block.push(stmt);
+        }
+        Parser.cache.set(this.hash, block);
       }
-      Parser.cache.set(this.hash, block);
+      return block;
+    } finally {
+      nodes.filename = previousFilename;
     }
-    return block;
   },
 
   /**

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -75,7 +75,6 @@ Renderer.prototype.render = function(fn){
   }
 
   try {
-    nodes.filename = this.options.filename;
     // parse
     var ast = parser.parse();
 
@@ -133,7 +132,6 @@ Renderer.prototype.deps = function(filename){
     , parser = new Parser(this.str, opts);
 
   try {
-    nodes.filename = opts.filename;
     // parse
     var ast = parser.parse()
       , resolver = new DepsResolver(ast, opts);

--- a/lib/visitor/deps-resolver.js
+++ b/lib/visitor/deps-resolver.js
@@ -21,7 +21,7 @@ var Visitor = require('./')
 
 var DepsResolver = module.exports = function DepsResolver(root, options) {
   this.root = root;
-  this.filename = options.filename;
+  this.filename = options.filename || root.filename;
   this.paths = options.paths || [];
   this.paths.push(dirname(options.filename || '.'));
   this.options = options;

--- a/lib/visitor/evaluator.js
+++ b/lib/visitor/evaluator.js
@@ -131,12 +131,12 @@ var Evaluator = module.exports = function Evaluator(root, options) {
   this.globals = options.globals || {};
   this.paths = options.paths || [];
   this.prefix = options.prefix || '';
-  this.filename = options.filename;
+  this.filename = options.filename || root.filename;
   this.includeCSS = options['include css'];
   this.resolveURL = functions.url
     && 'resolver' == functions.url.name
     && functions.url.options;
-  this.paths.push(dirname(options.filename || '.'));
+  this.paths.push(dirname(this.filename || '.'));
   this.stack.push(this.global = new Frame(root));
   this.warnings = options.warn;
   this.options = options;

--- a/lib/visitor/evaluator.js
+++ b/lib/visitor/evaluator.js
@@ -62,45 +62,51 @@ function importFile(node, file, literal) {
 
   // Parse the file
   importStack.push(file);
+  var previousFilename = nodes.filename;
   nodes.filename = file;
-
-  if (literal) {
-    literal = new nodes.Literal(str.replace(/\r\n?/g, '\n'));
-    literal.lineno = literal.column = 1;
-    if (!this.resolveURL) return literal;
-  }
-
-  // parse
-  var block = new nodes.Block
-    , parser = new Parser(str, utils.merge({ root: block }, this.options));
-
-  try {
-    block = parser.parse();
-  } catch (err) {
-    var line = parser.lexer.lineno
-      , column = parser.lexer.column;
-
-    if (literal && this.includeCSS && this.resolveURL) {
-      this.warn('ParseError: ' + file + ':' + line + ':' + column + '. This file included as-is');
-      return literal;
-    } else {
-      err.filename = file;
-      err.lineno = line;
-      err.column = column;
-      err.input = str;
-      throw err;
+  try{
+    if (literal) {
+      literal = new nodes.Literal(str.replace(/\r\n?/g, '\n'));
+      literal.lineno = literal.column = 1;
+      if (!this.resolveURL) return literal;
     }
+
+    // parse
+    var block = new nodes.Block
+      , options = utils.merge({ root: block }, this.options);
+    options.filename = file;
+    var parser = new Parser(str, options);
+
+    try {
+      block = parser.parse();
+    } catch (err) {
+      var line = parser.lexer.lineno
+  , column = parser.lexer.column;
+
+      if (literal && this.includeCSS && this.resolveURL) {
+        this.warn('ParseError: ' + file + ':' + line + ':' + column + '. This file included as-is');
+        return literal;
+      } else {
+        err.filename = file;
+        err.lineno = line;
+        err.column = column;
+        err.input = str;
+        throw err;
+      }
+    }
+
+    // Evaluate imported "root"
+    block = block.clone(this.currentBlock);
+    block.parent = this.currentBlock;
+    block.scope = false;
+    var ret = this.visit(block);
+    importStack.pop();
+    if (!this.resolveURL || this.resolveURL.nocheck) this.paths.pop();
+
+    return ret;
+  } finally{
+    nodes.filename = previousFilename;
   }
-
-  // Evaluate imported "root"
-  block = block.clone(this.currentBlock);
-  block.parent = this.currentBlock;
-  block.scope = false;
-  var ret = this.visit(block);
-  importStack.pop();
-  if (!this.resolveURL || this.resolveURL.nocheck) this.paths.pop();
-
-  return ret;
 }
 
 /**
@@ -244,7 +250,14 @@ Evaluator.prototype.populateGlobalScope = function(){
 Evaluator.prototype.evaluate = function(){
   debug('eval %s', this.filename);
   this.setup();
-  return this.visit(this.root);
+
+  var previousFilename = nodes.filename;
+  nodes.filename = this.filename;
+  try{
+    return this.visit(this.root);
+  } finally{
+    nodes.filename = previousFilename;
+  }
 };
 
 /**

--- a/lib/visitor/sourcemapper.js
+++ b/lib/visitor/sourcemapper.js
@@ -32,7 +32,7 @@ var SourceMapper = module.exports = function SourceMapper(root, options){
   this.column = 1;
   this.lineno = 1;
   this.contents = {};
-  this.filename = options.filename;
+  this.filename = options.filename || root.filename;
   this.dest = options.dest;
 
   var sourcemap = options.sourcemap;


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
 * Scope `node.filename` changes so that it's easier to follow how this global variable is changed
 * Root AST node call its parent to get a filename too
 * Visitors gets their `this.filename` from the root node if not provided in the options

<!-- Why are these changes necessary? -->

**Why**:

I am implementing a loader to retrieve all the variables defined in a stylus file (and its imports). The easiest way to do it is to look into `Evaluator.global.scope`. However, the setup adds builtin globals and filtering is necessary. The best way to filter is to check if the AST node's filename is `null`. However, the parser does not set the filename of the ast nodes.

fix #2699 

While implementing this, I encountered several problems with the `nodes.filename` global variable :
 * It's hard to track when and if it is restored
 * It can leak to other tests

This is why I added code to precisely mark the scope of the modification, and restore its previous value then.

<!-- How were these changes implemented? -->

**How**:

See commit changes (it's quite short)

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [X] Documentation N/A
- [ ] Unit Tests
- [X] Code complete
- [ ] Changelog

<!-- feel free to add additional comments -->

I am waiting your review before writing changelogs etc.
