### PR TITLE
use https instead of http where supported

### DIFF
--- a/bin/stylus
+++ b/bin/stylus
@@ -398,16 +398,16 @@ function help(name) {
   switch (browser) {
     case 'safari':
     case 'webkit':
-      url = 'https://developer.apple.com/library/safari/search/?q=' + name;
+      url = 'https://developer.apple.com/search/?q=' + name;
       break;
     case 'opera':
-      url = 'https://dev.opera.com/search/?term=' + name;
+      url = 'https://dev.opera.com/search/?q=' + name;
       break;
     case 'w3c':
       url = 'https://www.google.com/search?q=site%3Awww.w3.org%2FTR+' + name;
       break;
     case 'ms':
-      url = 'https://social.msdn.microsoft.com/search/en-US/ie?query=' + name + '&refinement=59%2c61';
+      url = 'https://learn.microsoft.com/en-us/search/?terms=' + name;
       break;
     case 'caniuse':
       url = 'https://caniuse.com/#search=' + name;
@@ -416,7 +416,7 @@ function help(name) {
       url = 'https://www.google.com/search?q=site%3Awww.quirksmode.org+' + name;
       break;
     default:
-      url = 'https://developer.mozilla.org/en/CSS/' + name;
+      url = 'https://developer.mozilla.org/en-US/docs/Web/CSS/' + name;
   }
 
   switch (process.platform) {

--- a/bin/stylus
+++ b/bin/stylus
@@ -410,7 +410,7 @@ function help(name) {
       url = 'https://learn.microsoft.com/en-us/search/?terms=' + name;
       break;
     case 'caniuse':
-      url = 'https://caniuse.com/#search=' + name;
+      url = 'https://caniuse.com/?search=' + name;
       break;
     case 'quirksmode':
       url = 'https://www.google.com/search?q=site%3Awww.quirksmode.org+' + name;

--- a/bin/stylus
+++ b/bin/stylus
@@ -401,19 +401,19 @@ function help(name) {
       url = 'https://developer.apple.com/library/safari/search/?q=' + name;
       break;
     case 'opera':
-      url = 'http://dev.opera.com/search/?term=' + name;
+      url = 'https://dev.opera.com/search/?term=' + name;
       break;
     case 'w3c':
-      url = 'http://www.google.com/search?q=site%3Awww.w3.org%2FTR+' + name;
+      url = 'https://www.google.com/search?q=site%3Awww.w3.org%2FTR+' + name;
       break;
     case 'ms':
-      url = 'http://social.msdn.microsoft.com/search/en-US/ie?query=' + name + '&refinement=59%2c61';
+      url = 'https://social.msdn.microsoft.com/search/en-US/ie?query=' + name + '&refinement=59%2c61';
       break;
     case 'caniuse':
-      url = 'http://caniuse.com/#search=' + name;
+      url = 'https://caniuse.com/#search=' + name;
       break;
     case 'quirksmode':
-      url = 'http://www.google.com/search?q=site%3Awww.quirksmode.org+' + name;
+      url = 'https://www.google.com/search?q=site%3Awww.quirksmode.org+' + name;
       break;
     default:
       url = 'https://developer.mozilla.org/en/CSS/' + name;


### PR DESCRIPTION

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

there were some links using `http:` where `https:` is supported.

**Why**:

Even though the links changed would automatically redirect from `http:` to `https:`, there's no reason not to use `https:` directly.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [ ] Unit Tests N/A
- [ ] Code complete N/A
- [ ] Changelog N/A

<!-- feel free to add additional comments -->
