### PR TITLE
during compression, strips the unit of 0 only for <length> types. 

### DIFF
--- a/lib/visitor/compiler.js
+++ b/lib/visitor/compiler.js
@@ -413,8 +413,8 @@ Compiler.prototype.visitUnit = function(unit){
 
   // Compress
   if (this.compress) {
-    // Always return '0' unless the unit is a percentage, time, degree or fraction
-    if (!(['%', 's', 'ms', 'deg', 'fr'].includes(type)) && 0 == n) return '0';
+    // Remove the unit for a <length> of value 0
+    if (0 == n && (['cap', 'ch', 'cm', 'dvb', 'dvh', 'dvi', 'dvmax', 'dvmin', 'dvw', 'em', 'ex', 'ic', 'in', 'lh', 'lvb', 'lvh', 'lvi', 'lvmax', 'lvmin', 'lvw', 'mm', 'pc', 'pt', 'px', 'q', 'rcap', 'rch', 'rem', 'rex', 'ric', 'rlh', 'svb', 'svh', 'svi', 'svmax', 'svmin', 'svw', 'vb', 'vh', 'vi', 'vmax', 'vmin', 'vw'].includes(type))) return '0';
     // Omit leading '0' on floats
     if (float && n < 1 && n > -1) {
       return n.toString().replace('0.', '.') + type;

--- a/test/cases/compress.units.css
+++ b/test/cases/compress.units.css
@@ -1,1 +1,1 @@
-body{foo:0;foo:0;foo:15;foo:-15;foo:15px;foo:-15px}body{foo:.1;foo:-.1;foo:1.1;foo:-1.1;foo:.1;foo:-.1;foo:10.1;foo:-10.1}body{foo:0s;foo:0ms}body{foo:0deg;foo:15deg;foo:-15deg}body{foo:0fr;foo:15fr;foo:-15fr}
+body{foo:0;foo:0;foo:0;foo:0;foo:15;foo:-15;foo:15px;foo:-15px}body{foo:.1;foo:-.1;foo:1.1;foo:-1.1;foo:.1;foo:-.1;foo:10.1;foo:-10.1}body{foo:0s;foo:0ms}body{foo:0deg;foo:15deg;foo:-15deg}body{foo:0turn;foo:15turn;foo:-15turn}body{foo:0fr;foo:15fr;foo:-15fr}body{foo:0hz;foo:15hz;foo:-15hz}body{foo:0dpi;foo:15dpi;foo:-15dpi}

--- a/test/cases/compress.units.styl
+++ b/test/cases/compress.units.styl
@@ -1,6 +1,8 @@
 body
   foo 0
   foo 0px
+  foo 0em
+  foo 0svmin
   foo 15
   foo -15
   foo 15px
@@ -26,6 +28,21 @@ body
   foo -15deg
 
 body
+  foo 0turn
+  foo 15turn
+  foo -15turn
+
+body
   foo 0fr
   foo 15fr
   foo -15fr
+
+body
+  foo 0hz
+  foo 15hz
+  foo -15hz
+
+body
+  foo 0dpi
+  foo 15dpi
+  foo -15dpi


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

During compression, the `0+unit` value now only be striped if unit is of type [\<length>](https://w3c.github.io/csswg-drafts/css-values/#lengths)

**Why**:

Some units should not be removed (0rad, 0grad, 0turn, 0hz, 0dpi, ...)

**How**:

I now only allow type \<length> to be striped

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Unit Tests
- [x] Code complete
- [ ] Changelog

<!-- feel free to add additional comments -->
