### PR TITLE
avoid infinite loop in add-property

### DIFF
--- a/lib/functions/index.js
+++ b/lib/functions/index.js
@@ -5,7 +5,7 @@
  * MIT Licensed
  */
 
-exports['add-property'] = require('./add-property');
+exports['add-property-js'] = require('./add-property');
 exports.adjust = require('./adjust');
 exports.alpha = require('./alpha');
 exports['base-convert'] = require('./base-convert');

--- a/lib/functions/index.styl
+++ b/lib/functions/index.styl
@@ -258,7 +258,7 @@ join(delim, vals...)
 // - It has the same effect as interpolation but allows users
 //   to opt for a functional style
 
-add-property-function = add-property
+add-property-function = add-property-js
 add-property(name, expr)
   if mixin
     {name} expr


### PR DESCRIPTION
**What** / **Why**:

https://github.com/stylus/stylus/issues/2771

**How**:

I suspect the infinite loop may be happening due to the local definition for `add-property` overshadowing the js definition, thereby creating an infinite loop. There seems to be a race condition for when that overshadowing happens, which occasionally allows the tests to pass.

**Checklist**:

- [ ] Documentation
- [ ] Unit Tests
- [ ] Code complete
- [ ] Changelog
