### PR TITLE
add support for CSS Values 4 viewport-relative units

### DIFF
--- a/lib/units.js
+++ b/lib/units.js
@@ -6,10 +6,18 @@
  */
 
 // units found in http://www.w3.org/TR/css3-values
+// and in https://www.w3.org/TR/css-values-4
 
 module.exports = [
     'em', 'ex', 'ch', 'rem' // relative lengths
-  , 'vw', 'vh', 'vmin', 'vmax' // relative viewport-percentage lengths
+
+  , 'vw', 'svw', 'lvw', 'dvw' // relative viewport-percentage lengths (including de-facto standard)
+  , 'vh', 'svh', 'lvh', 'dvh'
+  , 'vi', 'svi', 'lvi', 'dvi'
+  , 'vb', 'svb', 'lvb', 'dvb'
+  , 'vmin', 'svmin', 'lvmin', 'dvmin'
+  , 'vmax', 'svmax', 'lvmax', 'dvmax'
+
   , 'cm', 'mm', 'in', 'pt', 'pc', 'px' // absolute lengths
   , 'deg', 'grad', 'rad', 'turn' // angles
   , 's', 'ms' // times


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

The MR adds support for [viewport-relative units from CSS Values 4 (WD)](https://www.w3.org/TR/css-values-4/#viewport-relative-units), which became the de-facto standard by being [supported by all major browsers](https://caniuse.com/viewport-unit-variants) now.

**Why**:

It would be nice to enable people to use these units in their code.

**How**:

The array of units ( in `./lib/units.js`) was extended to support the new values.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Unit Tests
- [ ] Code complete
- [ ] Changelog

<!-- feel free to add additional comments -->
