### PR TITLE
Add the spin_ryb to the Built-in Functions

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+0.60.0 / 2022-06-20
+===================
+ * feat: add spin_ryb Built-in function [#2803](https://github.com/stylus/stylus/pull/2803)
+
 0.59.0 / 2022-08-13
 ===================
   * deps: switching from css to @adobe/css-tools [#2709](https://github.com/stylus/stylus/pull/2709)

--- a/docs/docs/bifs.md
+++ b/docs/docs/bifs.md
@@ -272,6 +272,15 @@ spin(#ff0000, 90deg)
 // => #80ff00
 ```
 
+### spin_ryb(color, amount)
+
+Spins hue of the given `color` by `amount` on the artistic RYB colorwheel.
+
+```stylus
+spin(#ff0000, 180deg)
+// => #00ff00
+```
+
 ### grayscale(color)
 
 Gives the grayscale equivalent of the given color. Equivalent to `desaturate(color, 100%)`.

--- a/lib/functions/index.js
+++ b/lib/functions/index.js
@@ -70,3 +70,4 @@ exports.use = require('./use');
 exports.warn = require('./warn');
 exports['-math-prop'] = require('./math-prop');
 exports['-prefix-classes'] = require('./prefix-classes');
+exports.spin_ryb = require('./spin_ryb');

--- a/lib/functions/spin_ryb.js
+++ b/lib/functions/spin_ryb.js
@@ -1,0 +1,132 @@
+var nodes = require('../nodes')
+  , hsla = require('./hsla');
+
+/**
+ * Rotate a color on the RGB color wheel using the RYB color model.
+ *
+ * Example:
+ * 
+ *    spin_ryb(#f00, 180)
+ *    // => #0f0
+ * 
+ * @param {RGBA|HSLA} color - The color to rotate.
+ * @param {Expression} amount - The angle in degrees to rotate the color.
+ * @return {RGBA} - The rotated color.
+ * @api public
+ */
+var spin_ryb = function(color, amount) {
+  var hslaColor = color.hsla;
+  var h = hslaColor.h;
+
+  if (amount instanceof nodes.Unit) {
+    // Extract the numeric value and unit from amount
+    var value = amount.val;
+    var unit = amount.type;
+
+    if (unit === 'deg') {
+      // Angle is already in degrees
+      amount = value;
+    } else if (unit === 'rad') {
+      // Convert radians to degrees
+      amount = value * (180 / Math.PI);
+    }
+  }
+
+  amount = amount % 360;
+
+  var wheel = [
+    [0, 0],
+    [15, 8],
+    [30, 16],
+    [45, 24],
+    [60, 31],
+    [75, 37],
+    [90, 42],
+    [105, 41],
+    [120, 52],
+    [135, 70],
+    [150, 92],
+    [165, 111],
+    [180, 120],
+    [195, 144],
+    [210, 161],
+    [225, 178],
+    [240, 204],
+    [255, 212],
+    [270, 228],
+    [285, 245],
+    [300, 264],
+    [315, 279],
+    [330, 296],
+    [345, 328],
+    [360, 0]
+  ];
+
+  // Find the closest hue in the wheel
+  var closest = null;
+  var minDiff = Number.MAX_SAFE_INTEGER;
+  var index;
+
+  for (var i = 0; i < wheel.length; i++) {
+    var entry = wheel[i];
+    var diff = Math.abs(h - entry[0]);
+    if (diff < minDiff) {
+      minDiff = diff;
+      closest = entry;
+      index = i;
+    }
+  }
+
+  var x0 = closest[0];
+  var y0 = closest[1];
+  var x1 = wheel[(index + 1) % wheel.length][0];
+  var y1 = wheel[(index + 1) % wheel.length][1];
+
+  if (y1 < y0) {
+    y1 += 360;
+  }
+
+  var a = x0 + ((x1 - x0) * (h - y0)) / (y1 - y0);
+  a = (a + amount) % 360;
+
+  // Find the closest hue in the wheel again
+  closest = null;
+  minDiff = Number.MAX_SAFE_INTEGER;
+
+  for (var j = 0; j < wheel.length; j++) {
+    var entry = wheel[j];
+    var diff = Math.abs(a - entry[0]);
+    if (diff < minDiff) {
+      minDiff = diff;
+      closest = entry;
+      index = j;
+    }
+  }
+
+  x0 = closest[0];
+  y0 = closest[1];
+  x1 = wheel[(index + 1) % wheel.length][0];
+  y1 = wheel[(index + 1) % wheel.length][1];
+
+  if (y1 < y0) {
+    y1 += 360;
+  }
+
+  var newHue;
+  if (x1 === x0) {
+    newHue = y0;
+  } else {
+    newHue = y0 + ((y1 - y0) * (a - x0)) / (x1 - x0);
+  }
+
+  newHue = newHue % 360;
+
+  return hsla(
+    new nodes.Unit(newHue),
+    new nodes.Unit(hslaColor.s),
+    new nodes.Unit(hslaColor.l),
+    new nodes.Unit(hslaColor.a)
+  );
+};
+spin_ryb.params = ['color', 'amount'];
+module.exports = spin_ryb;

--- a/test/cases/bifs.spin_ryb.css
+++ b/test/cases/bifs.spin_ryb.css
@@ -1,0 +1,8 @@
+body {
+  foo: #0f0;
+  foo: #f00;
+  foo: #fbff00;
+  foo: #f50;
+  foo: #9a00ff;
+  foo: #57ff00;
+}

--- a/test/cases/bifs.spin_ryb.styl
+++ b/test/cases/bifs.spin_ryb.styl
@@ -1,0 +1,7 @@
+body
+  foo: spin_ryb(#f00, 180deg)
+  foo: spin_ryb(#0f0, 180deg)
+  foo: spin_ryb(#00f, 180deg)
+  foo: spin_ryb(#0ff, 180deg)
+  foo: spin_ryb(#ff0, 180deg)
+  foo: spin_ryb(#f0f, 180deg)


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Mimic the spin built-in function using the RYB "artistic" color wheel instead of the HSL one.

**Why**:

People are used to see green as complementary color for red, blue for yellow and so on.  Rotation on the HSL wheel does not match what is expected from this point of view.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Unit Tests
- [x] Code complete
- [x] Changelog

<!-- feel free to add additional comments -->
