### PR TITLE
chore: Remove node v10 and v12 which are EOL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node: [10, 12, 14, 16, 20]
+        node: [14, 16, 20]
     runs-on: ${{ matrix.os }}
     steps:
      - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   node_tests:
-    name: 'Test stylus on ${{matrix.os}} with node18'
+    name: 'Test stylus on ${{matrix.os}} with node20'
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
@@ -22,7 +22,7 @@ jobs:
      - uses: actions/setup-node@v4
        with:
          # The Node.js version to configure
-         node-version: '18'
+         node-version: '20'
      - name: Install npm dependencies
        run: npm install
      - name: Print node & npm version
@@ -36,7 +36,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node: [14, 16, 20]
+        node: [14, 16, 18, 21]
     runs-on: ${{ matrix.os }}
     steps:
      - uses: actions/checkout@v4
@@ -51,13 +51,13 @@ jobs:
        run: npm run test
 
   benchmark:
-    name: 'Run stylus benchmark with node18'
+    name: 'Run stylus benchmark with node20'
     runs-on: ubuntu-latest
     steps:
      - uses: actions/checkout@v4
      - uses: actions/setup-node@v4
        with:
-         node-version: '18'
+         node-version: '20'
      - name: Install npm dependencies
        run: npm install
      - name: Print put node & npm version
@@ -72,7 +72,7 @@ jobs:
      - uses: actions/checkout@v4
      - uses: actions/setup-node@v4
        with:
-         node-version: '18'
+         node-version: '20'
      - name: Print put node & npm version
        run: node --version && npm --version
      - name: Install yarn global
@@ -89,7 +89,7 @@ jobs:
      - uses: actions/checkout@v4
      - uses: actions/setup-node@v4
        with:
-         node-version: '18'
+         node-version: '20'
      - name: Print put node & npm version
        run: node --version && npm --version
      - name: Install npm dependencies

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,3 @@
-0.61.0 / 
-===================
-  * chore: drop support for NodeJS 10 and 12
-
 0.60.0 / 2023-08-30
 ===================
   * feat: support [deno](https://deno.com) [#2813](https://github.com/stylus/stylus/pull/2813)

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+0.61.0 / 
+===================
+  * chore: drop support for NodeJS 10 and 12
+
 0.60.0 / 2023-08-30
 ===================
   * feat: support [deno](https://deno.com) [#2813](https://github.com/stylus/stylus/pull/2813)


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Removed node v10 and v12 from test matrix according to the conversation here: https://github.com/stylus/stylus/pull/2818#issuecomment-1776646949

<!-- Why are these changes necessary? -->

**Why**: Both 10 and 12 are EOL since 2.5 and 1.5 years respectively. Test cases are failing when trying to update `@adobe/css-tools` to a version that's not vulnerable.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [x] Unit Tests
- [x] Code complete
- [x] Changelog 

<!-- feel free to add additional comments -->
