### PR TITLE
Fix Super Calls

### DIFF
--- a/lib/nodes/object.js
+++ b/lib/nodes/object.js
@@ -127,7 +127,7 @@ module.exports = class Object extends Node {
       case '!=':
         return this.operate('==', right).negate();
       default:
-        return super.operate.call(op, right);
+        return super.operate(op, right);
     }
   };
 

--- a/lib/visitor/sourcemapper.js
+++ b/lib/visitor/sourcemapper.js
@@ -64,7 +64,7 @@ module.exports = class SourceMapper extends Compiler {
    */
 
   compile() {
-    var css = super.compile.call(this)
+    var css = super.compile()
       , out = this.basename + '.map'
       , url = this.normalizePath(this.dest
         ? join(this.dest, out)
@@ -156,7 +156,7 @@ module.exports = class SourceMapper extends Compiler {
    */
 
   visitLiteral(lit) {
-    var val = super.visitLiteral.call(this, lit)
+    var val = super.visitLiteral(lit)
       , filename = this.normalizePath(lit.filename)
       , indentsRe = /^\s+/
       , lines = val.split('\n');


### PR DESCRIPTION
**What**:

Fixes super calls like `super.method.call(this, ...args)` by replacing them with direct super calls like `super.method(...args)`
 
**Why**:

I did this change to avoid the `.call` pattern.

It also fixes #2820 which is a regression caused by the Classes PR (#2813) where code was transformed incorrectly on my part, which I apologise for.

The code before the PR was:

```js
Node.prototype.operate.call(this, op, right)
```

and the code was incorrectly transformed into

```js
super.operate.call(op, right);
```

when it should have instead been

```js
super.operate(op, right);
```

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Unit Tests
- [x] Code complete
- [ ] Changelog

<!-- feel free to add additional comments -->
