### PR TITLE
chore(deps): bump glob from 7.1.6 to 10.4.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node: [14, 16, 18, 22]
+        node: [16, 18, 22]
     runs-on: ${{ matrix.os }}
     steps:
      - uses: actions/checkout@v4

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -88,8 +88,8 @@ exports.find = function(path, paths, ignore) {
 
   // Absolute
   if (exports.absolute(path)) {
-    if ((found = glob.sync(path)).length) {
-      return found;
+    if ((found = glob.sync(path, {windowsPathsNoEscape: true, posix: true})).length) {
+      return found.sort();
     }
   }
 
@@ -97,8 +97,8 @@ exports.find = function(path, paths, ignore) {
   while (i--) {
     lookup = join(paths[i], path);
     if (ignore == lookup) continue;
-    if ((found = glob.sync(lookup)).length) {
-      return found;
+    if ((found = glob.sync(lookup, {windowsPathsNoEscape: true, posix: true})).length) {
+      return found.sort();
     }
   }
 };

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@adobe/css-tools": "~4.3.3",
     "debug": "^4.3.2",
     "glob": "^10.4.5",
-    "sax": "~1.4.1"
+    "sax": "~1.4.1",
     "source-map": "^0.7.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "main": "./index.js",
   "browserify": "./lib/browserify.js",
   "engines": {
-    "node": "*"
+    "node": ">=16"
   },
   "bin": {
     "stylus": "./bin/stylus"
@@ -30,7 +30,7 @@
   "dependencies": {
     "@adobe/css-tools": "~4.3.3",
     "debug": "^4.3.2",
-    "glob": "^7.1.6",
+    "glob": "^10.4.5",
     "sax": "~1.3.0",
     "source-map": "^0.7.3"
   },


### PR DESCRIPTION
Breaking change: Node 16+ is required

<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Update the version of glob

**Why**:

Glob 7 is deprecated

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Unit Tests
- [x] Code complete
- [ ] Changelog

<!-- feel free to add additional comments -->
