### PR TITLE
fix: too many newline causing maximum call stack size error

### DIFF
--- a/lib/lexer.js
+++ b/lib/lexer.js
@@ -701,6 +701,11 @@ exports = module.exports = class Lexer {
       }
 
       // Blank line
+      while (this.str[0] === '\n') {
+        if(this.str[1] !== '\n') break;
+        this.skip(this.str[0]);
+      }
+
       if ('\n' == this.str[0]) return this.advance();
 
       // Outdent

--- a/test/run.js
+++ b/test/run.js
@@ -20,8 +20,8 @@ addSuite('integration', readDir('test/cases'), function(test) {
       .include(__dirname + '/cases/import.basic');
 
   // TODO skip url test ci on windows platform
-  // cause '\r\n' and `\n` generate different hash string   
-  // relative commit https://github.com/stylus/stylus/commit/fe0c090a5c0c0db73f4afd3a803af33996548d01 
+  // cause '\r\n' and `\n` generate different hash string
+  // relative commit https://github.com/stylus/stylus/commit/fe0c090a5c0c0db73f4afd3a803af33996548d01
   if (isWindows && (test || '').includes('functions.url')) {
     return;
   }
@@ -207,6 +207,25 @@ describe('JS API', function() {
     });
     style.render().should.equal('body{color:#f00}/*# sourceMappingURL=build.css.map */');
     style.sourcemap.sources[0].should.equal('../test.styl');
+  });
+});
+
+describe('Maximum call stack size', function() {
+  it('newline', function() {
+    // too many line breaks can cause stack overflow during parsing
+    // then number of line breaks is affected by the device being run.
+    var code = `
+foo
+    font-size 20px
+${'\n'.repeat(10000)}
+bar
+    font-size 20px
+`;
+
+    var style = stylus(code, {
+      compress: true
+    });
+    style.render().should.equal('foo{font-size:20px}bar{font-size:20px}');
   });
 });
 

--- a/test/run.js
+++ b/test/run.js
@@ -3,6 +3,8 @@
  * Module dependencies.
  */
 
+const { ParseError } = require('../lib/errors');
+
 var stylus = require('../')
   , fs = require('fs')
   , isWindows = process.platform === 'win32'
@@ -226,6 +228,27 @@ bar
       compress: true
     });
     style.render().should.equal('foo{font-size:20px}bar{font-size:20px}');
+  });
+
+  it('line & column of error messages should be correct after multiple line breaks.', function() {
+    var style = stylus(`
+.foo
+    font-size 20px
+
+${'\n'.repeat(200)}
+// comment
+.bar
+  /
+
+// error here
+.foo
+    color red
+`);
+    style.render((err) => {
+      should.exist(err);
+      should.equal(err instanceof ParseError, true);
+      should.equal(err.message.startsWith("stylus:210:1"), true)
+    });
   });
 });
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

```stylus
// foo.stylus
foo
    font-size 20px

// too many newline (\n, e.g: 10000

bar
    font-size 20px
```

run 

```shell
stylus foo.stylus
```

This will result in an error:

```ignore
/path/to/path/stylus/bin/stylus:684
              throw err;
              ^

RangeError: ./i.styl:4406:1
   4402|
   4403|
   4404|
   4405|
   4406|
---------^
   4407|
   4408|
   4409|

Maximum call stack size exceeded

    at RegExp.exec (<anonymous>)
    at Lexer.null (/path/to/path/stylus/lib/lexer.js:417:38)
    at Lexer.advance (/path/to/path/stylus/lib/lexer.js:193:21)
    at Lexer.newline (/path/to/path/stylus/lib/lexer.js:704:44)
    at Lexer.advance (/path/to/path/stylus/lib/lexer.js:198:17)
    at Lexer.newline (/path/to/path/stylus/lib/lexer.js:704:44)
    at Lexer.advance (/path/to/path/stylus/lib/lexer.js:198:17)
    at Lexer.newline (/path/to/path/stylus/lib/lexer.js:704:44)
    at Lexer.advance (/path/to/path/stylus/lib/lexer.js:198:17)
    at Lexer.newline (/path/to/path/stylus/lib/lexer.js:704:44)
```

<!-- Why are these changes necessary? -->

**Why**:

when there are continuous line breaks, ``advance`` will be called recursively [here](https://github.com/stylus/stylus/blob/dev/lib/lexer.js#L704), and then `newline` will be called again. `newline` will call `advance` again. When there are too many line breaks, the recursive call will exceed the stack size.



<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Unit Tests
- [x] Code complete
- [ ] Changelog

<!-- feel free to add additional comments -->
