### PR TITLE
feat: support modern CSS @scope at-rules

### DIFF
--- a/docs/docs/atrules.md
+++ b/docs/docs/atrules.md
@@ -37,6 +37,55 @@ Would compile to
   }
 }
 ```
+
+## `@scope`
+
+Stylus supports modern CSS `@scope` as a normal at-rule:
+
+```stylus
+@scope (.root)
+  .child
+    color: red
+
+@scope (.root) to (.limit)
+  .title
+    color: blue
+```
+
+Would compile to
+
+```css
+@scope (.root) {
+  .child {
+    color: #f00;
+  }
+}
+@scope (.root) to (.limit) {
+  .title {
+    color: #00f;
+  }
+}
+```
+
+Stylus also keeps its legacy `@scope <selector>` behavior:
+
+```stylus
+@scope #sidebar
+
+a
+  color: red
+```
+
+Would compile to
+
+```css
+#sidebar a {
+  color: #f00;
+}
+```
+
+That legacy form works differently from CSS `@scope`: it prefixes subsequent root-level selectors with the given selector, rather than keeping selectors unchanged inside an `@scope` block.
+
 ## Unknown at-rules
 
 Stylus supports any yet unknown @-rules, so it is future-friendly, as any new at-rules in CSS could be written in indentation-based syntax of Stylus and would be rendered perfectly:

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -1088,6 +1088,42 @@ module.exports = class Parser {
 
   scope() {
     this.expect('scope');
+
+    var i = 1
+      , tok = this.peek()
+      , type = tok.type
+      , modern;
+
+    while ('space' == type || 'comment' == type) {
+      tok = this.lookahead(++i);
+      type = tok.type;
+    }
+
+    if ('{' == type || ('ident' == type && 'to' == (tok.val.name || tok.val.string))) {
+      this.error('expected "(" after @scope, got {peek}');
+    }
+
+    modern = '(' == type;
+
+    if (modern) {
+      var node = new nodes.Atrule('scope');
+
+      this.skipSpacesAndComments();
+      node.segments = this.selectorParts();
+
+      while (tok = this.accept(',')) {
+        node.segments.push(new nodes.Literal(','));
+        if (tok.space) node.segments.push(new nodes.Literal(' '));
+        node.segments = node.segments.concat(this.selectorParts());
+      }
+
+      this.skipSpacesAndComments();
+      this.state.push('atrule');
+      node.block = this.block(node);
+      this.state.pop();
+      return node;
+    }
+
     var selector = this.selectorParts()
       .map(function (selector) { return selector.val; })
       .join('');

--- a/test/cases/css.scope.advanced.css
+++ b/test/cases/css.scope.advanced.css
@@ -1,0 +1,28 @@
+@scope (.braced) {
+  .child {
+    color: #f00;
+  }
+}
+@scope (.feature) {
+  :scope {
+    color: #800080;
+  }
+}
+@scope (.article-body) to (:scope > figure) {
+  img {
+    border: 1px solid #000;
+  }
+}
+@scope (main > [data-scope=root]) to (.limit:hover) {
+  .target {
+    color: #008000;
+  }
+}
+@scope (.widget) {
+  .button {
+    color: #f00;
+  }
+  .button:hover {
+    color: #00f;
+  }
+}

--- a/test/cases/css.scope.advanced.styl
+++ b/test/cases/css.scope.advanced.styl
@@ -1,0 +1,23 @@
+@scope (.braced) {
+  .child {
+    color: red;
+  }
+}
+
+@scope (.feature)
+  :scope
+    color: purple
+
+@scope (.article-body) to (:scope > figure)
+  img
+    border: 1px solid black
+
+@scope (main > [data-scope=root]) to (.limit:hover)
+  .target
+    color: green
+
+@scope (.widget)
+  .button
+    color: red
+    &:hover
+      color: blue

--- a/test/cases/css.scope.css
+++ b/test/cases/css.scope.css
@@ -1,0 +1,5 @@
+@scope (.root) {
+  .child {
+    color: #f00;
+  }
+}

--- a/test/cases/css.scope.limits.css
+++ b/test/cases/css.scope.limits.css
@@ -1,0 +1,18 @@
+@scope ( .feature ) to ( .limit ) {
+  .spacey {
+    color: #00f;
+  }
+}
+@scope ( .feature , .sidebar ) to ( .limit , .ceiling ) {
+  .range {
+    color: #008000;
+  }
+}
+@scope (.modern) to (.limit) {
+  .inside-modern {
+    color: #ff0;
+  }
+}
+#legacy a {
+  color: #000;
+}

--- a/test/cases/css.scope.limits.styl
+++ b/test/cases/css.scope.limits.styl
@@ -1,0 +1,15 @@
+@scope ( .feature ) to ( .limit )
+  .spacey
+    color: blue
+
+@scope ( .feature , .sidebar ) to ( .limit , .ceiling )
+  .range
+    color: green
+
+@scope #legacy
+@scope (.modern) to (.limit)
+  .inside-modern
+    color: yellow
+
+a
+  color: black

--- a/test/cases/css.scope.styl
+++ b/test/cases/css.scope.styl
@@ -1,0 +1,3 @@
+@scope (.root)
+  .child
+    color: red

--- a/test/run.js
+++ b/test/run.js
@@ -192,6 +192,24 @@ describe('JS API', function() {
     }).should.throw(/import loop has been found/);
   });
 
+  it('throws for modern @scope without a body', function() {
+    (function() {
+      stylus('@scope (.root)', { filename: 'scope-error.styl' }).render();
+    }).should.throw(/expected "indent"/);
+  });
+
+  it('throws for implicit-root @scope limits', function() {
+    (function() {
+      stylus('@scope to (.limit) { .global { color: blue; } }', { filename: 'scope-limit-only-error.styl' }).render();
+    }).should.throw(/expected "\(" after @scope/);
+  });
+
+  it('throws for bare @scope blocks without an explicit root or limit', function() {
+    (function() {
+      stylus('@scope { .global { color: blue; } }', { filename: 'scope-bare-error.styl' }).render();
+    }).should.throw(/expected "\(" after @scope/);
+  });
+
   it('conditional assignment with define', function() {
     stylus('foo ?= baz; body { test: foo }', { compress: true })
       .define('foo', new stylus.nodes.Literal('bar'))


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Add support for `@scope` CSS at-rule

<!-- Why are these changes necessary? -->

**Why**: 

Currently stylus incorrectly compiles `@scope`. For example:

```
@scope (.root)
  .child
    color: red
```

compiles to:

```
(.root) .child {
  color: #f00;
}
```

but the result should have been:

```
@scope (.root) {
  .child {
    color: #f00;
  }
}
```

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Unit Tests
- [x] Code complete
- [ ] Changelog

<!-- feel free to add additional comments -->
