### PR TITLE
fix: guard against undefined selector.val in normalizer

### DIFF
--- a/lib/visitor/normalizer.js
+++ b/lib/visitor/normalizer.js
@@ -241,7 +241,8 @@ module.exports = class Normalizer extends Visitor {
 
     // normalize interpolated selectors with comma
     group.nodes.forEach(function (selector, i) {
-      if (!~selector.val.indexOf(',')) return;
+      // selector.val may be undefined before interpolation
+      if (!selector.val || !~selector.val.indexOf(',')) return;
       if (~selector.val.indexOf('\\,')) {
         selector.val = selector.val.replace(/\\,/g, ',');
         return;


### PR DESCRIPTION
## Summary
- Skip comma-splitting when `selector.val` is undefined so `visitGroup` does not call `.indexOf` on a missing value.
- Fixes #2327.

## Test plan
- [x] `npm test` (382 passing)
- [x] Existing selector/interpolation cases still pass